### PR TITLE
Initial device trees for Congo and Morocco platforms.

### DIFF
--- a/arch/arm64/boot/dts/aspeed/Makefile
+++ b/arch/arm64/boot/dts/aspeed/Makefile
@@ -2,3 +2,4 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
 	ast2700-evb.dtb \
 	aspeed-bmc-amd-congo.dtb \
 	aspeed-bmc-amd-marley.dtb \
+	aspeed-bmc-amd-morocco.dtb \

--- a/arch/arm64/boot/dts/aspeed/Makefile
+++ b/arch/arm64/boot/dts/aspeed/Makefile
@@ -1,3 +1,4 @@
 dtb-$(CONFIG_ARCH_ASPEED) += \
 	ast2700-evb.dtb \
+	aspeed-bmc-amd-congo.dtb \
 	aspeed-bmc-amd-marley.dtb \

--- a/arch/arm64/boot/dts/aspeed/amd-flash-layout-128.dtsi
+++ b/arch/arm64/boot/dts/aspeed/amd-flash-layout-128.dtsi
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-2.0+
+
+partitions {
+	compatible = "fixed-partitions";
+	#address-cells = <1>;
+	#size-cells = <1>;
+
+	u-boot@0 {
+		reg = <0x0 0x200000>; // 2MB
+		label = "u-boot";
+	};
+
+	u-boot-env@200000 {
+		reg = <0x200000 0x20000>; // 128KB
+		label = "u-boot-env";
+	};
+
+	kernel@220000 {
+		reg = <0x220000 0x1000000>; // 16MB
+		label = "kernel";
+	};
+
+	rofs@b20000 {
+		reg = <0x1220000 0x2000000>; // 32MB
+		label = "rofs";
+	};
+
+	rwfs@6000000 {
+		reg = <0x3220000 0x4DE0000>; // 79.75MB
+		label = "rwfs";
+	};
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -1,0 +1,371 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2024 AMD Inc.
+// Author: Mahesh Kurapati <mahesh.kurapati@amd.com>
+
+/dts-v1/;
+
+#include "aspeed-g7.dtsi"
+#include "dt-bindings/gpio/aspeed-gpio.h"
+#include <dt-bindings/i2c/i2c.h>
+
+/ {
+	model = "AMD Congo VRB";
+	compatible = "amd,congo-bmc", "aspeed,ast2700";
+	
+	chosen {
+		stdout-path = &uart12;
+		bootargs = "console=ttyS12,115200n8";
+	};
+
+	firmware {
+		optee: optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+
+	memory@400000000 {
+		device_type = "memory";
+		reg = <0x4 0x00000000 0x0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		mcu_fw: mcu-firmware@42fe00000 {
+			reg = <0x4 0x2fe00000 0x0 0x200000>;
+			no-map;
+		};
+
+		atf: trusted-firmware-a@430000000 {
+			reg = <0x4 0x30000000 0x0 0x80000>;
+			no-map;
+		};
+
+		optee_core: optee_core@430080000 {
+			reg = <0x4 0x30080000 0x0 0x1000000>;
+			no-map;
+		};
+
+		video_engine_memory: jpegbuffer {
+			size = <0x02000000>;	/* 32M */
+			alignment = <0x01000000>;
+			compatible = "shared-dma-pool";
+			reusable;
+		};
+
+		pcc_memory: pccbuffer {
+                        reg = <0xE0000000 0x00001000>; /* 4K */
+			no-map;
+                };
+	};
+	aliases {
+#ifdef EEPROM_PROG_ENABLE
+		i2c100 = &channel_0_0;
+#endif
+		i2c121 = &temp_2_1;
+		i2c122 = &fans_2_2;
+		i2c123 = &fans_2_3;
+		i2c126 = &adc_2_6;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	ethphy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+};
+
+&pinctrl1 {
+	pinctrl_rgmii0_driving: rgmii0_driving {
+		pins = "C20", "C19", "A8", "R14", "A7", "P14",
+		       "D20", "A6", "B6", "N14", "B7", "B8";
+		drive-strength = <1>;
+	};
+};
+
+&mac0 {
+	status = "okay";
+	phy-mode = "rgmii";
+	phy-handle = <&ethphy0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rgmii0_default &pinctrl_rgmii0_driving>;
+};
+
+&fmc {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_fwspi_quad_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "bmc";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+#include "amd-flash-layout-128.dtsi"
+	};
+
+	flash@1 {
+		status = "okay";
+		m25p,fast-read;
+		label = "mpflash";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi0_default &pinctrl_spi0_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <16000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_spi1_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <16000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+//BMC Console
+&uart12 {
+	status = "okay";
+};
+
+&i2c7 {
+	status = "okay";
+	scmeeprom@50 {
+		compatible = "atmel,24c08";
+		reg = <0x50>;
+	};
+};
+
+&i2c8 {
+	// Net name SCM_I2C<0>
+	status = "okay";
+	hpmeeprom@50 {
+		compatible = "microchip,24lc256","atmel,24c256";
+		reg = <0x50>;
+	};
+#ifdef EEPROM_PROG_ENABLE
+	// SCM brd_id, Congo brd_id, CLK
+	i2cswitch@70 {
+		compatible = "nxp,pca9546";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		channel_0_0: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			// BRD ID eeprom
+			brdreveeprom@51 {
+				compatible = "microchip,24lc256","atmel,24c256";
+				reg = <0x51>;
+			};
+			// SCM BRD ID eeprom
+			scmbrdeeprom@52 {
+				compatible = "microchip,24lc256","atmel,24c256";
+				reg = <0x52>;
+			};
+		};
+	};
+#endif
+};
+
+&i2c10 {
+	// Net name i2c2 (SCM_I2C_SDA<2>) - FAN/LM75/ADC
+	status = "okay";
+
+	i2cswitch@73 {
+		compatible = "nxp,pca9548";
+		reg = <0x73>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		temp_2_1: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		fans_2_2: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+		};
+
+		fans_2_3: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+		};
+
+		adc_2_6: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&gpio0 {
+        gpio-line-names =
+                /*A0-A7*/       "","","","","","","","",
+                /*B0-B7*/       "","","","","","","","",
+                /*C0-C7*/       "","","","","","","","",
+                /*D0-D7*/       "","","","","","","","",
+                /*E0-E7*/       "","","","","","","","",
+                /*F0-F7*/       "","","","","","","","",
+                /*G0-G7*/       "","","","","","","","",
+                /*H0-H7*/       "","","","","","","","",
+                /*I0-I7*/       "","","","","","","","",
+                /*J0-J7*/       "","","","","","","","",
+                /*K0-K7*/       "","","","","","","","",
+                /*L0-L7*/       "","","","","","","","",
+                /*M0-M7*/       "","","","","","","","",
+                /*N0-N7*/       "","","","","","","","",
+                /*O0-O7*/       "","","","","","","","",
+                /*P0-P7*/       "","","","","","","","",
+                /*Q0-Q7*/       "","","","","","","","",
+                /*R0-R7*/       "","","","","","","","",
+                /*S0-S7*/       "","","","","","","","",
+                /*T0-T7*/       "","","","","","","","",
+                /*U0-U7*/       "","","","","","","","",
+                /*V0-V7*/       "","","","","","","","",
+                /*W0-W7*/       "","","","","","","","",
+                /*X0-X7*/       "","","","","","","","",
+                /*Y0-Y7*/       "","","","","","","","",
+                /*Z0-Z7*/       "","","","","","","","",
+                /*AA0-AA7*/     "","","","","","","","",
+                /*AB0-AB7*/     "HPM_STBY_EN","P0_MGMT_ASSERT_CLR_CMOS",
+				"P0_MGMT_MON_PROCHOT_L","","","",
+				"P0_MGMT_ASSERT_NMI_BTN_L",
+				"MGMT_SYS_MON_ATX_PWR_OK",
+                /*AC0-AC7*/     "P0_PRESENT_L","P0_MGMT_MON_RSMRST_L",
+				"P0_MGMT_MON_POST_COMPLETE",
+				"P0_MGMT_MON_THERMTRIP_L",
+				"P0_MGMT_MON_PWR_GOOD","P0_ASSERT_RSMRST",
+				"P0_MGMT_SOC_RESET_L",
+				"P0_MGMT_MON_PSP_SOFT_FUSE_NOTIFY",
+                /*AD0-AD7*/     "P0_I3C_APML_ALERT_L","MGMT_HDT_SEL",
+				"SCM_JTAG_DBREQ","JTAG_TRST_N","P1_PRESENT_L",
+				"","","",
+                /*AE0-AE7*/     "P0_MGMT_ASSERT_RST_BTN_L",
+				"P0_MGMT_ASSERT_PWR_BTN_L",
+				"P0_MGMT_MON_RST_BTN_L",
+				"P0_MGMT_MON_PWR_BTN_L","","","","";
+};
+
+&video0 {
+	status = "okay";
+	memory-region = <&video_engine_memory>;
+};
+
+&espi0 {
+	status = "okay";
+	perif-dma-mode;
+	oob-dma-mode;
+	flash-dma-mode;
+};
+
+&lpc0_pcc {
+        port-addr = <0x80>;
+        dma-mode;
+        A2600-15;
+        memory-region = <&pcc_memory>;
+        rec-mode = <0x1>;
+        port-addr-hbits-select = <0x1>;
+        port-addr-xbits = <0x3>;
+
+        status = "okay";
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-marley.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-marley.dts
@@ -102,7 +102,7 @@
 		spi-max-frequency = <50000000>;
 		spi-tx-bus-width = <4>;
 		spi-rx-bus-width = <4>;
-#include "aspeed-flash-layout-128.dtsi"
+#include "amd-flash-layout-128.dtsi"
 	};
 
 	flash@1 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1,0 +1,460 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2024 AMD Inc.
+// Author: Mahesh Kurapati <mahesh.kurapati@amd.com>
+
+/dts-v1/;
+
+#include "aspeed-g7.dtsi"
+#include "dt-bindings/gpio/aspeed-gpio.h"
+#include <dt-bindings/i2c/i2c.h>
+
+/ {
+	model = "AMD Morocco VRB";
+	compatible = "amd,morocco-bmc", "aspeed,ast2700";
+	
+	chosen {
+		stdout-path = &uart12;
+		bootargs = "console=ttyS12,115200n8";
+	};
+
+	firmware {
+		optee: optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+
+	memory@400000000 {
+		device_type = "memory";
+		reg = <0x4 0x00000000 0x0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		mcu_fw: mcu-firmware@42fe00000 {
+			reg = <0x4 0x2fe00000 0x0 0x200000>;
+			no-map;
+		};
+
+		atf: trusted-firmware-a@430000000 {
+			reg = <0x4 0x30000000 0x0 0x80000>;
+			no-map;
+		};
+
+		optee_core: optee_core@430080000 {
+			reg = <0x4 0x30080000 0x0 0x1000000>;
+			no-map;
+		};
+
+		video_engine_memory: jpegbuffer {
+			size = <0x02000000>;	/* 32M */
+			alignment = <0x01000000>;
+			compatible = "shared-dma-pool";
+			reusable;
+		};
+
+		pcc_memory: pccbuffer {
+                        reg = <0xE0000000 0x00001000>; /* 4K */
+			no-map;
+                };
+	};
+	aliases {
+
+#ifdef EEPROM_PROG_ENABLE
+		i2c100 = &channel_0_0;
+#endif
+		i2c121 = &temp_2_1;
+		i2c122 = &fans_2_2;
+		i2c123 = &fans_2_3;
+		i2c124 = &fans_2_4;
+		i2c125 = &fans_2_5;
+		i2c126 = &adc_2_6;
+		i2c127 = &pdb_adc_2_0;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	ethphy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+};
+
+&pinctrl1 {
+	pinctrl_rgmii0_driving: rgmii0_driving {
+		pins = "C20", "C19", "A8", "R14", "A7", "P14",
+		       "D20", "A6", "B6", "N14", "B7", "B8";
+		drive-strength = <1>;
+	};
+};
+
+&mac0 {
+	status = "okay";
+	phy-mode = "rgmii";
+	phy-handle = <&ethphy0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rgmii0_default &pinctrl_rgmii0_driving>;
+};
+
+&fmc {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_fwspi_quad_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "bmc";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+#include "amd-flash-layout-128.dtsi"
+	};
+
+	flash@1 {
+		status = "okay";
+		m25p,fast-read;
+		label = "mpflash";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi0_default &pinctrl_spi0_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <16000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_spi1_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <16000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+//BMC Console
+&uart12 {
+	status = "okay";
+};
+
+// I2C configs
+&i2c7 {
+	status = "okay";
+	scmeeprom@50 {
+		compatible = "atmel,24c08";
+		reg = <0x50>;
+	};
+};
+
+&i2c8 {
+	// Net name SCM_I2C<0>
+	status = "okay";
+	hpmeeprom@50 {
+		compatible = "microchip,24lc256","atmel,24c256";
+		reg = <0x50>;
+	};
+#ifdef EEPROM_PROG_ENABLE
+	// SCM brd_id, Congo brd_id, CLK
+	i2cswitch@70 {
+		compatible = "nxp,pca9546";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		channel_0_0: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			// BRD ID eeprom
+			brdreveeprom@51 {
+				compatible = "microchip,24lc256","atmel,24c256";
+				reg = <0x51>;
+			};
+			// SCM BRD ID eeprom
+			scmbrdeeprom@52 {
+				compatible = "microchip,24lc256","atmel,24c256";
+				reg = <0x52>;
+			};
+		};
+	};
+#endif
+};
+
+&i2c10 {
+	// Net name i2c2 (SCM_I2C2) - FAN/LM75/ADC
+	status = "okay";
+
+	i2cswitch@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		temp_2_1: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		fans_2_2: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+		};
+
+		fans_2_3: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+		};
+
+		fans_2_4: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+		};
+
+		fans_2_5: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+		};
+
+		adc_2_6: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+	i2cswitch@71 {
+		compatible = "nxp,pca9546";
+		reg = <0x71>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		pdb_adc_2_0: i2c@0 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&gpio0 {
+        gpio-line-names =
+                /*A0-A7*/       "","","","","","","","",
+                /*B0-B7*/       "","","","","","","","",
+                /*C0-C7*/       "","","","","","","","",
+                /*D0-D7*/       "","","","","","","","",
+                /*E0-E7*/       "","","","","","","","",
+                /*F0-F7*/       "","","","","","","","",
+                /*G0-G7*/       "","","","","","","","",
+                /*H0-H7*/       "","","","","","","","",
+                /*I0-I7*/       "","","","","","","","",
+                /*J0-J7*/       "","","","","","","","",
+                /*K0-K7*/       "","","","","","","","",
+                /*L0-L7*/       "","","","","","","","",
+                /*M0-M7*/       "","","","","","","","",
+                /*N0-N7*/       "","","","","","","","",
+                /*O0-O7*/       "","","","","","","","",
+                /*P0-P7*/       "","","","","","","","",
+                /*Q0-Q7*/       "","","","","","","","",
+                /*R0-R7*/       "","","","","","","","",
+                /*S0-S7*/       "","","","","","","","",
+                /*T0-T7*/       "","","","","","","","",
+                /*U0-U7*/       "","","","","","","","",
+                /*V0-V7*/       "","","","","","","","",
+                /*W0-W7*/       "","","","","","","","",
+                /*X0-X7*/       "","","","","","","","",
+                /*Y0-Y7*/       "","","","","","","","",
+                /*Z0-Z7*/       "","","","","","","","",
+                /*AA0-AA7*/     "","","","","","","","",
+                /*AB0-AB7*/     "HPM_STBY_EN","P0_MGMT_ASSERT_CLR_CMOS",
+				"P0_MGMT_MON_PROCHOT_L","","","",
+				"P0_MGMT_ASSERT_NMI_BTN_L",
+				"MGMT_SYS_MON_ATX_PWR_OK",
+                /*AC0-AC7*/     "P0_PRESENT_L","P0_MGMT_MON_RSMRST_L",
+				"P0_MGMT_MON_POST_COMPLETE",
+				"P0_MGMT_MON_THERMTRIP_L",
+				"P0_MGMT_MON_PWR_GOOD","P0_ASSERT_RSMRST",
+				"P0_MGMT_SOC_RESET_L",
+				"P0_MGMT_MON_PSP_SOFT_FUSE_NOTIFY",
+                /*AD0-AD7*/     "P0_I3C_APML_ALERT_L","MGMT_HDT_SEL",
+				"SCM_JTAG_DBREQ","JTAG_TRST_N","P1_PRESENT_L",
+				"","","",
+                /*AE0-AE7*/     "P0_MGMT_ASSERT_RST_BTN_L",
+				"P0_MGMT_ASSERT_PWR_BTN_L",
+				"P0_MGMT_MON_RST_BTN_L",
+				"P0_MGMT_MON_PWR_BTN_L","","","","";
+};
+
+&video0 {
+	status = "okay";
+	memory-region = <&video_engine_memory>;
+};
+
+&espi0 {
+	status = "okay";
+	perif-dma-mode;
+	oob-dma-mode;
+	flash-dma-mode;
+};
+
+&lpc0_pcc {
+        port-addr = <0x80>;
+        dma-mode;
+        A2600-15;
+        memory-region = <&pcc_memory>;
+        rec-mode = <0x1>;
+        port-addr-hbits-select = <0x1>;
+        port-addr-xbits = <0x3>;
+
+        status = "okay";
+};


### PR DESCRIPTION
ARM64: dts: aspeed: initial device tree for Congo and Morocco platform

This commit chain has the following changes:
- AMD specific flash layout dtsi file
- initial device tree for Congo
- initial device tree for Morocco
- Makefile change.

Tested: Verified on QEMU and Malta/Marley setup