### PR TITLE
ARM64: dts: aspeed: amd flash layout updates

### DIFF
--- a/arch/arm64/boot/dts/aspeed/amd-flash-layout-128.dtsi
+++ b/arch/arm64/boot/dts/aspeed/amd-flash-layout-128.dtsi
@@ -21,12 +21,12 @@ partitions {
 	};
 
 	rofs@b20000 {
-		reg = <0x1220000 0x2000000>; // 32MB
+		reg = <0x1220000 0x4DE0000>; // 77.875MB
 		label = "rofs";
 	};
 
 	rwfs@6000000 {
-		reg = <0x3220000 0x4DE0000>; // 79.75MB
+		reg = <0x6000000 0x2000000>; // 32MB
 		label = "rwfs";
 	};
 };


### PR DESCRIPTION
Added more flash space  rwfs partition and new layout is below

Following is the BMC SPI Flash Layout:
    - uboot     0x00      (2MB)
    - uboot-env 0x200000  (128KB)
    - kernel    0x220000  (16MB)
    - rofs      0x1220000 (77.875MB)
    - rwfs      0x3220000 (32MB)

Tested: verfied on QEMU and Malta/Marley platform.