### PR TITLE
Enable ltpi and uart9 for PRB

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -291,6 +291,16 @@
         status = "okay";
 };
 
-&jtag0 {
+&ltpi0 {
+	status = "okay";
+};
+
+&uart9 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+	status = "okay";
+};
+
+&jtag1 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -291,6 +291,16 @@
         status = "okay";
 };
 
-&jtag0 {
+&ltpi0 {
+	status = "okay";
+};
+
+&uart9 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+	status = "okay";
+};
+
+&jtag1 {
 	status = "okay";
 };


### PR DESCRIPTION
ARM64: dts: aspeed: enable ltpi, uart9, and jtag1 in PRB platform 
enable ltpi, uart9, and jtag1 in Kenya platform
enable ltpi, uart9, and jtag1 in Nigeria platform