### PR TITLE
Add KVM support for Congo and Morocco VRB

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -49,9 +49,9 @@
 			no-map;
 		};
 
-		video_engine_memory: jpegbuffer {
-			size = <0x02000000>;	/* 32M */
-			alignment = <0x01000000>;
+		video_engine_memory0: video0 {
+			size = <0x0 0x04000000>;
+			alignment = <0x0 0x00010000>;
 			compatible = "shared-dma-pool";
 			reusable;
 		};
@@ -402,7 +402,7 @@
 
 &video0 {
 	status = "okay";
-	memory-region = <&video_engine_memory>;
+	memory-region = <&video_engine_memory0>;
 };
 
 &espi0 {
@@ -432,4 +432,19 @@
        /delete-property/ pinctrl-names;
        /delete-property/ pinctrl-0;
        status = "okay";
+};
+&vhuba1 {
+	status = "okay";
+};
+
+&usb3ahp {
+	status = "okay";
+};
+
+&phy2a {
+	status = "okay";
+};
+
+&phy3a {
+	status = "okay";
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -49,9 +49,9 @@
 			no-map;
 		};
 
-		video_engine_memory: jpegbuffer {
-			size = <0x02000000>;	/* 32M */
-			alignment = <0x01000000>;
+		video_engine_memory0: video0 {
+			size = <0x0 0x04000000>;
+			alignment = <0x0 0x00010000>;
 			compatible = "shared-dma-pool";
 			reusable;
 		};
@@ -559,7 +559,7 @@
 
 &video0 {
 	status = "okay";
-	memory-region = <&video_engine_memory>;
+	memory-region = <&video_engine_memory0>;
 };
 
 &espi0 {
@@ -590,3 +590,18 @@
        /delete-property/ pinctrl-0;
        status = "okay";
 };
+&vhuba1 {
+        status = "okay";
+};
+
+&usb3ahp {
+	status = "okay";
+};
+&phy2a {
+	status = "okay";
+};
+
+&phy3a {
+	status = "okay";
+};
+

--- a/drivers/soc/aspeed/Makefile
+++ b/drivers/soc/aspeed/Makefile
@@ -10,3 +10,6 @@ obj-$(CONFIG_ASPEED_XDMA)		+= aspeed-xdma.o
 obj-$(CONFIG_ASPEED_UDMA)		+= aspeed-udma.o
 obj-$(CONFIG_AST2600_ESPI)              += ast2600-espi.o
 obj-$(CONFIG_AST2700_ESPI)              += ast2700-espi.o
+obj-$(CONFIG_ARCH_ASPEED)		+= aspeed-usb-phy.o
+obj-$(CONFIG_ARCH_ASPEED)		+= aspeed-usb-phy3.o
+obj-$(CONFIG_ARCH_ASPEED)		+= aspeed-usb-hp.o

--- a/drivers/soc/aspeed/aspeed-usb-hp.c
+++ b/drivers/soc/aspeed/aspeed-usb-hp.c
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright 2021 Aspeed Technology Inc.
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
+#include <linux/regmap.h>
+#include <asm/io.h>
+#include <linux/clk.h>
+#include <linux/reset.h>
+#include <linux/mfd/syscon.h>
+
+static const struct of_device_id aspeed_usb_hp_dt_ids[] = {
+	{
+		.compatible = "aspeed,ast2600-usb2ahp",
+	},
+	{
+		.compatible = "aspeed,ast2700-usb3ahp",
+	},
+	{
+		.compatible = "aspeed,ast2700-usb3bhp",
+	},
+		{
+		.compatible = "aspeed,ast2700-usb2ahp",
+	},
+	{
+		.compatible = "aspeed,ast2700-usb2bhp",
+	},
+};
+MODULE_DEVICE_TABLE(of, aspeed_usb_hp_dt_ids);
+
+static int aspeed_usb_hp_probe(struct platform_device *pdev)
+{
+	struct clk		*clk;
+	struct reset_control	*rst;
+	struct regmap		*device;
+	bool is_pcie_xhci;
+	int rc = 0;
+
+	if (of_device_is_compatible(pdev->dev.of_node,
+				    "ast2600-usb2ahp")) {
+		dev_info(&pdev->dev, "Initialized AST2600 USB2AHP\n");
+		return 0;
+	}
+
+	if (of_device_is_compatible(pdev->dev.of_node,
+				    "aspeed,ast2700-usb3ahp") ||
+	    of_device_is_compatible(pdev->dev.of_node,
+				    "aspeed,ast2700-usb3bhp")) {
+		is_pcie_xhci = true;
+	} else if (of_device_is_compatible(pdev->dev.of_node,
+					   "aspeed,ast2700-usb2ahp") ||
+		   of_device_is_compatible(pdev->dev.of_node,
+					   "aspeed,ast2700-usb2bhp")) {
+		is_pcie_xhci = false;
+	}
+	clk = devm_clk_get(&pdev->dev, NULL);
+	if (IS_ERR(clk))
+		return PTR_ERR(clk);
+
+	rc = clk_prepare_enable(clk);
+	if (rc) {
+		dev_err(&pdev->dev, "Unable to enable clock (%d)\n", rc);
+		return rc;
+	}
+
+	rst = devm_reset_control_get_shared(&pdev->dev, NULL);
+	if (IS_ERR(rst)) {
+		rc = PTR_ERR(rst);
+		goto err;
+	}
+	rc = reset_control_deassert(rst);
+	if (rc)
+		goto err;
+
+	device = syscon_regmap_lookup_by_phandle(pdev->dev.of_node, "aspeed,device");
+	if (IS_ERR(device)) {
+		dev_err(&pdev->dev, "failed to find device regmap\n");
+		goto err;
+	}
+
+	if (is_pcie_xhci) {
+		//EnPCIaMSI_EnPCIaIntA_EnPCIaMst_EnPCIaDev
+		/* Turn on PCIe xHCI without MSI */
+		regmap_update_bits(device, 0x70,
+				   BIT(19) | BIT(11) | BIT(3),
+				   BIT(19) | BIT(11) | BIT(3));
+	} else {
+		//EnPCIaMSI_EnPCIaIntA_EnPCIaMst_EnPCIaDev
+		/* Turn on PCIe EHCI without MSI */
+		regmap_update_bits(device, 0x70,
+				   BIT(18) | BIT(10) | BIT(2),
+				   BIT(18) | BIT(10) | BIT(2));
+	}
+	dev_info(&pdev->dev, "Initialized AST2700 USB Host PCIe\n");
+	return 0;
+err:
+	if (clk)
+		clk_disable_unprepare(clk);
+	return rc;
+}
+
+static int aspeed_usb_hp_remove(struct platform_device *pdev)
+{
+	dev_info(&pdev->dev, "Remove USB Host PCIe\n");
+
+	return 0;
+}
+
+static struct platform_driver aspeed_usb_hp_driver = {
+	.probe		= aspeed_usb_hp_probe,
+	.remove		= aspeed_usb_hp_remove,
+	.driver		= {
+		.name	= KBUILD_MODNAME,
+		.of_match_table	= aspeed_usb_hp_dt_ids,
+	},
+};
+module_platform_driver(aspeed_usb_hp_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Neal Liu <neal_liu@aspeedtech.com>");

--- a/drivers/soc/aspeed/aspeed-usb-phy.c
+++ b/drivers/soc/aspeed/aspeed-usb-phy.c
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright 2021 Aspeed Technology Inc.
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
+#include <linux/regmap.h>
+#include <linux/mfd/syscon.h>
+#include <asm/io.h>
+
+struct usb_phy_ctrl {
+	u32 offset;
+	u32 value;
+};
+
+static const struct of_device_id aspeed_usb_phy_dt_ids[] = {
+	{
+		.compatible = "aspeed,ast2600-uphyb",
+	},
+	{
+		.compatible = "aspeed,ast2700-phy2a",
+	},
+	{
+		.compatible = "aspeed,ast2700-phy2b",
+	},
+	{ }
+};
+MODULE_DEVICE_TABLE(of, aspeed_usb_phy_dt_ids);
+
+static int aspeed_usb_phy_probe(struct platform_device *pdev)
+{
+	struct device_node *node = pdev->dev.of_node;
+	struct usb_phy_ctrl *ctrl_data;
+	void __iomem *base;
+	struct regmap *scu;
+	int ctrl_num = 1;
+	int ret, i;
+	u32 val;
+
+	scu = syscon_regmap_lookup_by_phandle(pdev->dev.of_node, "aspeed,scu");
+	if (IS_ERR(scu)) {
+		dev_err(&pdev->dev, "cannot to find SCU regmap\n");
+		return -ENODEV;
+	}
+
+	if (of_device_is_compatible(pdev->dev.of_node,
+				    "aspeed,ast2600-uphyb")) {
+		/* Check SCU040[3] USB port B controller reset is deassert */
+		regmap_read(scu, 0x40, &val);
+		if ((val & BIT(3)))
+			return -EPROBE_DEFER;
+	}
+
+	if (of_device_is_compatible(pdev->dev.of_node,
+				    "aspeed,ast2700-phy2a")) {
+		/* Check SCU220[0] USB vHubA1 controller reset is deassert */
+		regmap_read(scu, 0x220, &val);
+		if ((val & BIT(0)))
+			return -EPROBE_DEFER;
+	}
+
+	if (of_device_is_compatible(pdev->dev.of_node,
+				    "aspeed,ast2700-phy2b")) {
+		/* Check SCU220[2] USB vHubB1 controller reset is deassert */
+		regmap_read(scu, 0x220, &val);
+		if ((val & BIT(2)))
+			return -EPROBE_DEFER;
+	}
+
+	ctrl_data = devm_kzalloc(&pdev->dev,
+				 sizeof(struct usb_phy_ctrl) * ctrl_num,
+				 GFP_KERNEL);
+	if (!ctrl_data)
+		return -ENOMEM;
+
+	base = of_iomap(node, 0);
+
+	ret = of_property_read_u32_array(node, "ctrl", (u32 *)ctrl_data,
+					 ctrl_num * 2);
+	if (ret < 0) {
+		dev_err(&pdev->dev, "Could not read ctrl property\n");
+		return -EINVAL;
+	}
+
+	for (i = 0; i < ctrl_num; i++)
+		writel(ctrl_data[i].value, base + ctrl_data[i].offset);
+
+	dev_info(&pdev->dev, "Initialized USB PHY\n");
+
+	return 0;
+}
+
+static int aspeed_usb_phy_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+static struct platform_driver aspeed_usb_phy_driver = {
+	.probe		= aspeed_usb_phy_probe,
+	.remove		= aspeed_usb_phy_remove,
+	.driver		= {
+		.name	= KBUILD_MODNAME,
+		.of_match_table	= aspeed_usb_phy_dt_ids,
+	},
+};
+module_platform_driver(aspeed_usb_phy_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Neal Liu <neal_liu@aspeedtech.com>");

--- a/drivers/soc/aspeed/aspeed-usb-phy3.c
+++ b/drivers/soc/aspeed/aspeed-usb-phy3.c
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: GPL-2.0+
+/*
+ * Copyright 2023 Aspeed Technology Inc.
+ */
+
+#include <linux/kernel.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of.h>
+#include <linux/of_address.h>
+#include <linux/regmap.h>
+#include <linux/mfd/syscon.h>
+#include <asm/io.h>
+#include <linux/clk.h>
+#include <linux/reset.h>
+
+#define	AST_USB_PHY3S00		0x800	/* PHY SRAM Control/Status #1 */
+#define AST_USB_PHY3S04		0x804	/* PHY SRAM Control/Status #2 */
+#define AST_USB_PHY3C00		0x808	/* PHY PCS Control/Status #1 */
+#define AST_USB_PHY3C04		0x80C	/* PHY PCS Control/Status #2 */
+#define AST_USB_PHY3P00		0x810	/* PHY PCS Protocol Setting #1 */
+#define AST_USB_PHY3P04		0x814	/* PHY PCS Protocol Setting #2 */
+#define AST_USB_PHY3P08		0x818	/* PHY PCS Protocol Setting #3 */
+#define AST_USB_PHY3P0C		0x81C	/* PHY PCS Protocol Setting #4	*/
+#define AST_USB_DWC_CMD		0xB80	/* DWC3 Commands base address offest */
+
+#define PHY3P00_DEFAULT		0xCE70000F	/* PHY PCS Protocol Setting #1 default value */
+#define PHY3P04_DEFAULT		0x49C00014	/* PHY PCS Protocol Setting #2 default value */
+#define PHY3P08_DEFAULT		0x5E406825	/* PHY PCS Protocol Setting #3 default value */
+#define PHY3P0C_DEFAULT		0x00000001	/* PHY PCS Protocol Setting #4 default value */
+
+#define DWC_CRTL_NUM	3
+
+#define USB_PHY3_INIT_DONE	BIT(15)	/* BIT15: USB3.1 Phy internal SRAM iniitalization done */
+#define USB_PHY3_SRAM_BYPASS	BIT(7)	/* USB3.1 Phy SRAM bypass */
+#define USB_PHY3_SRAM_EXT_LOAD	BIT(6)	/* USB3.1 Phy SRAM external load done */
+
+struct usb_dwc3_ctrl {
+	u32 offset;
+	u32 value;
+};
+
+static struct usb_dwc3_ctrl ctrl_data[DWC_CRTL_NUM] = {
+	{0xc100, 0x00000006},   /* AP Note 32 - Errata A0 */
+	{0xc12c, 0x0c854802},	/* Set DWC3 GUCTL for ref_clk */
+	{0xc630, 0x0c800020},	/* Set DWC3 GLADJ for ref_clk */
+};
+
+static const struct of_device_id aspeed_usb_phy3_dt_ids[] = {
+	{
+		.compatible = "aspeed,ast2700-phy3a",
+	},
+	{
+		.compatible = "aspeed,ast2700-phy3b",
+	},
+	{ }
+};
+MODULE_DEVICE_TABLE(of, aspeed_usb_phy3_dt_ids);
+
+static int aspeed_usb_phy3_probe(struct platform_device *pdev)
+{
+	struct device_node *node = pdev->dev.of_node;
+	void __iomem *reg_base;
+	u32 val;
+	bool phy_ext_load_quirk;
+	struct clk				*clk;
+	struct reset_control	*rst;
+	int timeout = 100;
+	int rc = 0;
+
+	int i, j;
+
+	clk = devm_clk_get(&pdev->dev, NULL);
+	if (IS_ERR(clk))
+		return PTR_ERR(clk);
+
+	rc = clk_prepare_enable(clk);
+	if (rc) {
+		dev_err(&pdev->dev, "Unable to enable clock (%d)\n", rc);
+		return rc;
+	}
+
+	rst = devm_reset_control_get_shared(&pdev->dev, NULL);
+	if (IS_ERR(rst)) {
+		rc = PTR_ERR(rst);
+		goto err;
+	}
+	rc = reset_control_deassert(rst);
+	if (rc)
+		goto err;
+
+	reg_base = of_iomap(node, 0);
+
+	while ((readl(reg_base + AST_USB_PHY3S00) & USB_PHY3_INIT_DONE)
+			!= USB_PHY3_INIT_DONE) {
+		usleep_range(100, 110);
+		if (--timeout == 0) {
+			dev_err(&pdev->dev, "Wait phy3 init timed out\n");
+			rc = -ETIMEDOUT;
+			goto err;
+		}
+	}
+
+	phy_ext_load_quirk =
+		device_property_read_bool(&pdev->dev, "aspeed,phy_ext_load_quirk");
+
+	val = readl(reg_base + AST_USB_PHY3S00);
+
+	if (phy_ext_load_quirk)
+		val |= USB_PHY3_SRAM_EXT_LOAD;
+	else
+		val |= USB_PHY3_SRAM_BYPASS;
+	writel(val, reg_base + AST_USB_PHY3S00);
+
+	/* Set protocol1_ext signals as default PHY3 settings based on SNPS documents.
+	 * Including PCFGI[54]: protocol1_ext_rx_los_lfps_en for better compatibility
+	 */
+	writel(PHY3P00_DEFAULT, reg_base + AST_USB_PHY3P00);
+	writel(PHY3P04_DEFAULT, reg_base + AST_USB_PHY3P04);
+	writel(PHY3P08_DEFAULT, reg_base + AST_USB_PHY3P08);
+	writel(PHY3P0C_DEFAULT, reg_base + AST_USB_PHY3P0C);
+
+	/* xHCI DWC specific command initially set when PCIe xHCI enable */
+	for (i = 0, j = AST_USB_DWC_CMD; i < DWC_CRTL_NUM; i++) {
+		/* 48-bits Command:
+		 * CMD1: Data -> DWC CMD [31:0], Address -> DWC CMD [47:32]
+		 * CMD2: Data -> DWC CMD [79:48], Address -> DWC CMD [95:80]
+		 * ... and etc.
+		 */
+		if (i % 2 == 0) {
+			writel(ctrl_data[i].value, reg_base + j);
+			j += 4;
+
+			writel(ctrl_data[i].offset & 0xFFFF, reg_base + j);
+		} else {
+			val = readl(reg_base + j) & 0xFFFF;
+			val |= ((ctrl_data[i].value & 0xFFFF) << 16);
+			writel(val, reg_base + j);
+			j += 4;
+
+			val = (ctrl_data[i].offset << 16) | (ctrl_data[i].value >> 16);
+			writel(val, reg_base + j);
+			j += 4;
+		}
+	}
+
+	dev_info(&pdev->dev, "Initialized USB PHY3\n");
+
+	return 0;
+
+err:
+	if (clk)
+		clk_disable_unprepare(clk);
+	return rc;
+}
+
+static int aspeed_usb_phy3_remove(struct platform_device *pdev)
+{
+	return 0;
+}
+
+static struct platform_driver aspeed_usb_phy3_driver = {
+	.probe		= aspeed_usb_phy3_probe,
+	.remove		= aspeed_usb_phy3_remove,
+	.driver		= {
+		.name	= KBUILD_MODNAME,
+		.of_match_table	= aspeed_usb_phy3_dt_ids,
+	},
+};
+module_platform_driver(aspeed_usb_phy3_driver);
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Joe Wang <joe_wang@aspeedtech.com>");

--- a/drivers/usb/gadget/udc/aspeed-vhub/core.c
+++ b/drivers/usb/gadget/udc/aspeed-vhub/core.c
@@ -23,8 +23,17 @@
 #include <linux/of.h>
 #include <linux/regmap.h>
 #include <linux/dma-mapping.h>
+#include <linux/reset.h>
+#include <linux/mfd/syscon.h>
 
 #include "vhub.h"
+
+#define ASPEED_G7_SCU_VHUB_USB_FUNC_OFFSET	0x410
+struct ast_vhub_match_data {
+	u32 usb_mode_mask;
+	bool is_pcie_xhci;
+	u32 xhci_mode_mask;
+};
 
 void ast_vhub_done(struct ast_vhub_ep *ep, struct ast_vhub_req *req,
 		   int status)
@@ -239,6 +248,7 @@ void ast_vhub_init_hw(struct ast_vhub *vhub)
 	if (vhub->force_usb1)
 		ctrl |= VHUB_CTRL_FULL_SPEED_ONLY;
 
+	ctrl |= VHUB_CTRL_AUTO_REMOTE_WAKEUP;
 	ctrl |= VHUB_CTRL_UPSTREAM_CONNECT;
 	writel(ctrl, vhub->regs + AST_VHUB_CTRL);
 
@@ -279,7 +289,10 @@ static void ast_vhub_remove(struct platform_device *pdev)
 
 	if (vhub->clk)
 		clk_disable_unprepare(vhub->clk);
-
+#ifdef CONFIG_MACH_ASPEED_G7
+	if (vhub->rst)
+		reset_control_assert(vhub->rst);
+#endif
 	spin_unlock_irqrestore(&vhub->lock, flags);
 
 	if (vhub->ep0_bufs)
@@ -298,7 +311,12 @@ static int ast_vhub_probe(struct platform_device *pdev)
 	struct resource *res;
 	int i, rc = 0;
 	const struct device_node *np = pdev->dev.of_node;
-
+#ifdef CONFIG_MACH_ASPEED_G7
+	struct regmap *device;
+	struct regmap *scu;
+	const struct ast_vhub_match_data *pdata;
+	u32 scu_usb;
+#endif
 	vhub = devm_kzalloc(&pdev->dev, sizeof(*vhub), GFP_KERNEL);
 	if (!vhub)
 		return -ENOMEM;
@@ -337,6 +355,17 @@ static int ast_vhub_probe(struct platform_device *pdev)
 
 	platform_set_drvdata(pdev, vhub);
 
+#ifdef CONFIG_MACH_ASPEED_G7
+	vhub->rst = devm_reset_control_get_exclusive(&pdev->dev, NULL);
+
+	if (IS_ERR(vhub->rst)) {
+		rc = PTR_ERR(vhub->rst);
+		goto err;
+	}
+	rc = reset_control_assert(vhub->rst);
+	if (rc)
+		goto err;
+#endif
 	vhub->clk = devm_clk_get(&pdev->dev, NULL);
 	if (IS_ERR(vhub->clk)) {
 		rc = PTR_ERR(vhub->clk);
@@ -347,7 +376,56 @@ static int ast_vhub_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "Error couldn't enable clock (%d)\n", rc);
 		goto err;
 	}
+#ifdef CONFIG_MACH_ASPEED_G7
+	mdelay(10);
+	rc = reset_control_deassert(vhub->rst);
+	if (rc)
+		goto err;
 
+	pdata = of_device_get_match_data(&pdev->dev);
+	if (!pdata) {
+		dev_err(&pdev->dev, "failed to get match data\n");
+		rc = -EINVAL;
+		goto err;
+	}
+	scu = syscon_regmap_lookup_by_phandle(pdev->dev.of_node, "aspeed,scu");
+	if (IS_ERR(scu)) {
+		dev_err(&pdev->dev, "failed to find SCU regmap\n");
+		rc = PTR_ERR(scu);
+		goto err;
+	}
+
+	regmap_read(scu, ASPEED_G7_SCU_VHUB_USB_FUNC_OFFSET, &scu_usb);
+
+	device = syscon_regmap_lookup_by_phandle(pdev->dev.of_node,
+						 "aspeed,device");
+	if (IS_ERR(device)) {
+		dev_err(&pdev->dev, "failed to find PCIe device regmap\n");
+		rc = PTR_ERR(device);
+		goto err;
+	}
+	/* Check EHCI or xHCI to virtual hub */
+	if ((scu_usb & pdata->usb_mode_mask) == 0) {
+		if (pdata->is_pcie_xhci) {
+			/* Check PCIe xHCI or BMC xHCI to virtual hub */
+			if ((scu_usb & pdata->xhci_mode_mask) == 0) {
+				dev_info(&pdev->dev, "PCIe xHCI to vhub\n");
+				//EnPCIaMSI_EnPCIaIntA_EnPCIaMst_EnPCIaDev
+				/* Turn on PCIe xHCI without MSI */
+				regmap_update_bits(device, 0x70,
+						   BIT(19) | BIT(11) | BIT(3),
+						   BIT(19) | BIT(11) | BIT(3));
+			}
+		} else {
+			dev_info(&pdev->dev, "PCIe EHCI to vhub\n");
+			//EnPCIaMSI_EnPCIaIntA_EnPCIaMst_EnPCIaDev
+			/* Turn on PCIe EHCI without MSI */
+			regmap_update_bits(device, 0x70,
+					   BIT(18) | BIT(10) | BIT(2),
+					   BIT(18) | BIT(10) | BIT(2));
+		}
+	}
+#endif
 	/* Check if we need to limit the HW to USB1 */
 	max_speed = usb_get_maximum_speed(&pdev->dev);
 	if (max_speed != USB_SPEED_UNKNOWN && max_speed < USB_SPEED_HIGH)
@@ -367,6 +445,12 @@ static int ast_vhub_probe(struct platform_device *pdev)
 			      KBUILD_MODNAME, vhub);
 	if (rc) {
 		dev_err(&pdev->dev, "Failed to request interrupt\n");
+		goto err;
+	}
+
+	rc = dma_set_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
+	if (rc) {
+		dev_warn(&pdev->dev, "No suitable DMA available\n");
 		goto err;
 	}
 
@@ -412,6 +496,30 @@ static int ast_vhub_probe(struct platform_device *pdev)
 	return rc;
 }
 
+static const struct ast_vhub_match_data ast2700_vhuba0_match_data = {
+	.usb_mode_mask = GENMASK(25, 24),
+	.is_pcie_xhci = false,
+	.xhci_mode_mask = 0,
+};
+
+static const struct ast_vhub_match_data ast2700_vhubb0_match_data = {
+	.usb_mode_mask = GENMASK(29, 28),
+	.is_pcie_xhci = false,
+	.xhci_mode_mask = 0,
+};
+
+static const struct ast_vhub_match_data ast2700_vhuba1_match_data = {
+	.usb_mode_mask = GENMASK(3, 2),
+	.is_pcie_xhci = true,
+	.xhci_mode_mask = BIT_MASK(9),
+};
+
+static const struct ast_vhub_match_data ast2700_vhubb1_match_data = {
+	.usb_mode_mask = GENMASK(7, 6),
+	.is_pcie_xhci = true,
+	.xhci_mode_mask = BIT_MASK(10),
+};
+
 static const struct of_device_id ast_vhub_dt_ids[] = {
 	{
 		.compatible = "aspeed,ast2400-usb-vhub",
@@ -421,6 +529,22 @@ static const struct of_device_id ast_vhub_dt_ids[] = {
 	},
 	{
 		.compatible = "aspeed,ast2600-usb-vhub",
+	},
+	{
+		.compatible = "aspeed,ast2700-usb-vhuba0",
+		.data = &ast2700_vhuba0_match_data,
+	},
+	{
+		.compatible = "aspeed,ast2700-usb-vhubb0",
+		.data = &ast2700_vhubb0_match_data,
+	},
+	{
+		.compatible = "aspeed,ast2700-usb-vhuba1",
+		.data = &ast2700_vhuba1_match_data,
+	},
+	{
+		.compatible = "aspeed,ast2700-usb-vhubb1",
+		.data = &ast2700_vhubb1_match_data,
 	},
 	{ }
 };

--- a/drivers/usb/gadget/udc/aspeed-vhub/dev.c
+++ b/drivers/usb/gadget/udc/aspeed-vhub/dev.c
@@ -116,10 +116,14 @@ static int ast_vhub_dev_feature(struct ast_vhub_dev *d,
 
 	if (wValue == USB_DEVICE_REMOTE_WAKEUP) {
 		d->wakeup_en = is_set;
-		return std_req_complete;
-	}
+		val = readl(d->vhub->regs + AST_VHUB_CTRL);
+		if (is_set)
+			writel(val | VHUB_CTRL_AUTO_REMOTE_WAKEUP,
+			       d->vhub->regs + AST_VHUB_CTRL);
 
-	if (wValue == USB_DEVICE_TEST_MODE) {
+		return std_req_complete;
+
+	} else if (wValue == USB_DEVICE_TEST_MODE) {
 		val = readl(d->vhub->regs + AST_VHUB_CTRL);
 		val &= ~GENMASK(10, 8);
 		val |= VHUB_CTRL_SET_TEST_MODE((wIndex >> 8) & 0x7);
@@ -239,7 +243,7 @@ int ast_vhub_std_dev_request(struct ast_vhub_ep *ep,
 		d->gadget.speed = ep->vhub->speed;
 		if (d->gadget.speed > d->driver->max_speed)
 			d->gadget.speed = d->driver->max_speed;
-		DDBG(d, "fist packet, captured speed %d\n",
+		DDBG(d, "first packet, captured speed %d\n",
 		     d->gadget.speed);
 	}
 

--- a/drivers/usb/gadget/udc/aspeed-vhub/epn.c
+++ b/drivers/usb/gadget/udc/aspeed-vhub/epn.c
@@ -340,7 +340,9 @@ static int ast_vhub_epn_queue(struct usb_ep* u_ep, struct usb_request *u_req,
 	struct ast_vhub *vhub = ep->vhub;
 	unsigned long flags;
 	bool empty;
-	int rc;
+	int rc = 0;
+
+	spin_lock_irqsave(&vhub->lock, flags);
 
 	/* Paranoid checks */
 	if (!u_req || !u_req->complete || !u_req->buf) {
@@ -349,14 +351,16 @@ static int ast_vhub_epn_queue(struct usb_ep* u_ep, struct usb_request *u_req,
 			dev_warn(&vhub->pdev->dev, "complete=%p internal=%d\n",
 				 u_req->complete, req->internal);
 		}
-		return -EINVAL;
+		rc = -EINVAL;
+		goto out;
 	}
 
 	/* Endpoint enabled ? */
 	if (!ep->epn.enabled || !u_ep->desc || !ep->dev || !ep->d_idx ||
 	    !ep->dev->enabled) {
 		EPDBG(ep, "Enqueuing request on wrong or disabled EP\n");
-		return -ESHUTDOWN;
+		rc = -ESHUTDOWN;
+		goto out;
 	}
 
 	/* Map request for DMA if possible. For now, the rule for DMA is
@@ -383,10 +387,15 @@ static int ast_vhub_epn_queue(struct usb_ep* u_ep, struct usb_request *u_req,
 		if (rc) {
 			dev_warn(&vhub->pdev->dev,
 				 "Request mapping failure %d\n", rc);
-			return rc;
+			goto out;
 		}
 	} else
 		u_req->dma = 0;
+
+	if (ep->dev->wakeup_en) {
+		EPVDBG(ep, "Wakeup host first\n");
+		ast_vhub_hub_wake_all(vhub);
+	}
 
 	EPVDBG(ep, "enqueue req @%p\n", req);
 	EPVDBG(ep, " l=%d dma=0x%x zero=%d noshort=%d noirq=%d is_in=%d\n",
@@ -400,9 +409,8 @@ static int ast_vhub_epn_queue(struct usb_ep* u_ep, struct usb_request *u_req,
 	req->act_count = 0;
 	req->active = false;
 	req->last_desc = -1;
-	spin_lock_irqsave(&vhub->lock, flags);
-	empty = list_empty(&ep->queue);
 
+	empty = list_empty(&ep->queue);
 	/* Add request to list and kick processing if empty */
 	list_add_tail(&req->queue, &ep->queue);
 	if (empty) {
@@ -411,9 +419,10 @@ static int ast_vhub_epn_queue(struct usb_ep* u_ep, struct usb_request *u_req,
 		else
 			ast_vhub_epn_kick(ep, req);
 	}
+out:
 	spin_unlock_irqrestore(&vhub->lock, flags);
 
-	return 0;
+	return rc;
 }
 
 static void ast_vhub_stop_active_req(struct ast_vhub_ep *ep,
@@ -786,6 +795,20 @@ static void ast_vhub_epn_dispose(struct usb_ep *u_ep)
 	ep->dev = NULL;
 }
 
+static void ast_vhub_epn_flush(struct usb_ep *u_ep)
+{
+	struct ast_vhub_ep *ep = to_ast_ep(u_ep);
+	struct ast_vhub *vhub = ep->vhub;
+	unsigned long flags;
+
+	EPDBG(ep, "flushing !\n");
+
+	spin_lock_irqsave(&vhub->lock, flags);
+	/* This will clear out all the request of the endpoint and send requests done messages. */
+	ast_vhub_nuke(ep, -EINVAL);
+	spin_unlock_irqrestore(&vhub->lock, flags);
+}
+
 static const struct usb_ep_ops ast_vhub_epn_ops = {
 	.enable		= ast_vhub_epn_enable,
 	.disable	= ast_vhub_epn_disable,
@@ -796,6 +819,7 @@ static const struct usb_ep_ops ast_vhub_epn_ops = {
 	.set_wedge	= ast_vhub_epn_set_wedge,
 	.alloc_request	= ast_vhub_alloc_request,
 	.free_request	= ast_vhub_free_request,
+	.fifo_flush	= ast_vhub_epn_flush,
 };
 
 struct ast_vhub_ep *ast_vhub_alloc_epn(struct ast_vhub_dev *d, u8 addr)

--- a/drivers/usb/gadget/udc/aspeed-vhub/vhub.h
+++ b/drivers/usb/gadget/udc/aspeed-vhub/vhub.h
@@ -388,6 +388,9 @@ struct ast_vhub {
 	spinlock_t			lock;
 	struct work_struct		wake_work;
 	struct clk			*clk;
+#ifdef CONFIG_MACH_ASPEED_G7
+	struct reset_control *rst;
+#endif
 
 	/* EP0 DMA buffers allocated in one chunk */
 	void				*ep0_bufs;
@@ -419,6 +422,7 @@ struct ast_vhub {
 
 	/* Upstream bus speed captured at bus reset */
 	unsigned int			speed;
+	u8				current_config;
 
 	/* Standard USB Descriptors of the vhub. */
 	struct usb_device_descriptor	vhub_dev_desc;

--- a/drivers/usb/gadget/udc/aspeed_udc.c
+++ b/drivers/usb/gadget/udc/aspeed_udc.c
@@ -156,7 +156,7 @@
 #define AST_EP_DMA_DESC_PID_DATA1	(2 << 14)
 #define AST_EP_DMA_DESC_PID_MDATA	(3 << 14)
 #define EP_DESC1_IN_LEN(x)		((x) & 0x1fff)
-#define AST_EP_DMA_DESC_MAX_LEN		(7680) /* Max packet length for trasmit in 1 desc */
+#define AST_EP_DMA_DESC_MAX_LEN		(4096) /* Max packet length for trasmit in 1 desc */
 
 struct ast_udc_request {
 	struct usb_request	req;
@@ -1301,6 +1301,7 @@ static int ast_udc_start(struct usb_gadget *gadget,
 	UDC_DBG(udc, "\n");
 	udc->driver = driver;
 	udc->gadget.dev.of_node = udc->pdev->dev.of_node;
+	udc->gadget.dev.of_node_reused = true;
 
 	for (i = 0; i < AST_UDC_NUM_ENDPOINTS; i++) {
 		ep = &udc->ep[i];

--- a/drivers/usb/host/uhci-hcd.h
+++ b/drivers/usb/host/uhci-hcd.h
@@ -445,7 +445,9 @@ struct uhci_hcd {
 	short load[MAX_PHASE];			/* Periodic allocations */
 
 	struct clk *clk;			/* (optional) clock source */
-
+#ifdef CONFIG_MACH_ASPEED_G7
+	struct reset_control *rsts;		/* (optional) clock reset */
+#endif
 	/* Reset host controller */
 	void	(*reset_hc) (struct uhci_hcd *uhci);
 	int	(*check_and_reset_hc) (struct uhci_hcd *uhci);

--- a/drivers/usb/host/uhci-platform.c
+++ b/drivers/usb/host/uhci-platform.c
@@ -11,6 +11,7 @@
 #include <linux/of.h>
 #include <linux/device.h>
 #include <linux/platform_device.h>
+#include <linux/reset.h>
 
 static int uhci_platform_init(struct usb_hcd *hcd)
 {
@@ -80,7 +81,7 @@ static int uhci_hcd_platform_probe(struct platform_device *pdev)
 	 * Since shared usb code relies on it, set it here for now.
 	 * Once we have dma capability bindings this can go away.
 	 */
-	ret = dma_coerce_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(32));
+	ret = dma_coerce_mask_and_coherent(&pdev->dev, DMA_BIT_MASK(64));
 	if (ret)
 		return ret;
 
@@ -113,7 +114,8 @@ static int uhci_hcd_platform_probe(struct platform_device *pdev)
 		}
 		if (of_device_is_compatible(np, "aspeed,ast2400-uhci") ||
 		    of_device_is_compatible(np, "aspeed,ast2500-uhci") ||
-		    of_device_is_compatible(np, "aspeed,ast2600-uhci")) {
+		    of_device_is_compatible(np, "aspeed,ast2600-uhci") ||
+		    of_device_is_compatible(np, "aspeed,ast2700-uhci")) {
 			uhci->is_aspeed = 1;
 			dev_info(&pdev->dev,
 				 "Enabled Aspeed implementation workarounds\n");
@@ -131,7 +133,19 @@ static int uhci_hcd_platform_probe(struct platform_device *pdev)
 		dev_err(&pdev->dev, "Error couldn't enable clock (%d)\n", ret);
 		goto err_rmr;
 	}
+#ifdef CONFIG_MACH_ASPEED_G7
+	uhci->rsts = devm_reset_control_array_get_optional_shared(&pdev->dev);
+	if (IS_ERR(uhci->rsts)) {
+		ret = PTR_ERR(uhci->rsts);
+		goto err_clk;
+	}
 
+	mdelay(10);
+
+	ret = reset_control_deassert(uhci->rsts);
+	if (ret)
+		goto err_clk;
+#endif
 	ret = platform_get_irq(pdev, 0);
 	if (ret < 0)
 		goto err_clk;


### PR DESCRIPTION
Added video, vHUB over PCIe nodes for Congo platform.
Added drivers updates for USB gadget, phy and host.


Tested and verified on Congo VRB