### PR TITLE
arch:arm64:boot:dts: Add JTAG1 for AMD VRB

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -600,3 +600,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <2>;
 };
+
+&jtag1 {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -701,3 +701,7 @@
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <2>;
 };
+
+&jtag1 {
+	status = "okay";
+};


### PR DESCRIPTION
Enable JTAG1 for AMD VRB Congo device Tree.
yaapd application is using JTAG1 device.

Tested: run yaapd in Congo