### PR TITLE
arm: dts: aspeed-g7: update i2c clock speed to 400khz

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -255,6 +255,7 @@
 
 &i2c7 {
 	status = "okay";
+        clock-frequency = <400000>;
 	scmeeprom@50 {
 		compatible = "atmel,24c08";
 		reg = <0x50>;
@@ -264,6 +265,7 @@
 &i2c8 {
 	// Net name SCM_I2C<0>
 	status = "okay";
+        clock-frequency = <400000>;
 	hpmeeprom@50 {
 		compatible = "microchip,24lc256","atmel,24c256";
 		reg = <0x50>;
@@ -329,7 +331,7 @@
 &i2c10 {
 	// Net name i2c2 (SCM_I2C_SDA<2>) - FAN/LM75/ADC
 	status = "okay";
-
+        clock-frequency = <400000>;
 	i2cswitch@73 {
 		compatible = "nxp,pca9548";
 		reg = <0x73>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -262,6 +262,7 @@
 // I2C configs
 &i2c7 {
 	status = "okay";
+        clock-frequency = <400000>;
 	scmeeprom@50 {
 		compatible = "atmel,24c08";
 		reg = <0x50>;
@@ -271,6 +272,7 @@
 &i2c8 {
 	// Net name SCM_I2C<0>
 	status = "okay";
+        clock-frequency = <400000>;
 	hpmeeprom@50 {
 		compatible = "microchip,24lc256","atmel,24c256";
 		reg = <0x50>;
@@ -336,6 +338,7 @@
 &i2c9 {
 	// Net name SCM_I2C<1>
 	status = "okay";
+        clock-frequency = <400000>;
 	// SCM brd_id, Congo brd_id, CLK
 	i2cswitch@70 {
 		compatible = "nxp,pca9546";
@@ -397,7 +400,7 @@
 &i2c10 {
 	// Net name i2c2 (SCM_I2C2) - FAN/LM75/ADC
 	status = "okay";
-
+        clock-frequency = <400000>;
 	i2cswitch@70 {
 		compatible = "nxp,pca9548";
 		reg = <0x70>;


### PR DESCRIPTION
Modified i2c clock speed to 400khz for i2c-7,8,9,10.

Tested:- Verified on Congo and Morocco Platforms.