### PR TITLE
ARM64: dts: aspeed: PRB Add support for USB2

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -434,7 +434,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         status = "okay";
 };
 
-&usb2bhp {
+&ehci1 {
 	status = "okay";
 };
 


### PR DESCRIPTION
BMC is a master on USB2.
Add ehci1 to support BMC as a USB2 master.

tested: verified in Nigeria