### PR TITLE
Apml i3c

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -449,8 +449,8 @@
 &i3c4 {
 	status = "okay";
 	initial-role = "primary";
-	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
-	i3c-scl-hz = <10000000>;
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 
 	sbtsi_p0_0: sbtsi@4c,22400000001 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -319,9 +319,9 @@
 &i3c4 {
         status = "okay";
         initial-role = "primary";
-        bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
-        i3c-scl-hz = <10000000>;
-        i2c-scl-hz = <1000000>;
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
+	i2c-scl-hz = <1000000>;
 
         sbtsi_p0_0: sbtsi@4c,22400000001 {
                 reg = <0x4c 0x224 0x00000001>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -607,9 +607,10 @@
 &i3c4 {
 	status = "okay";
 	initial-role = "primary";
-	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
-	i3c-scl-hz = <10000000>;
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
+
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
 		reg = <0x4c 0x224 0x00000001>;
 		assigned-address = <0x4c>;
@@ -619,6 +620,24 @@
 		assigned-address = <0x3c>;
 	};
 };
+
+&i3c5 {
+	status = "okay";
+	initial-role = "primary";
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
+	i2c-scl-hz = <1000000>;
+
+	sbtsi_p1_0: sbtsi@48,22400000001 {
+		reg = <0x48 0x224 0x00000001>;
+		assigned-address = <0x48>;
+	};
+	sbrmi_p1_1: sbrmi@38,22400000002 {
+		reg = <0x38 0x224 0x00000002>;
+		assigned-address = <0x38>;
+	};
+};
+
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -633,6 +652,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
+
 	i3c_hub0: i3chub0@70,4CC00000000 {
 		reg = <0x70 0x4CC 0x00000000>;
 		assigned-address = <0x70>;
@@ -658,6 +678,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
+
 	i3c_hub2: i3chub0@70,4CC00000000 {
 		reg = <0x70 0x4CC 0x00000000>;
 		assigned-address = <0x70>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -386,9 +386,10 @@
 &i3c4 {
 	status = "okay";
 	initial-role = "primary";
-	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
-	i3c-scl-hz = <6000000>;
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
+
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
 		reg = <0x4c 0x224 0x00000001>;
 		assigned-address = <0x4c>;
@@ -396,6 +397,23 @@
 	sbrmi_p0_1: sbrmi@3c,22400000002 {
 		reg = <0x3c 0x224 0x00000002>;
 		assigned-address = <0x3c>;
+	};
+};
+
+&i3c5 {
+	status = "okay";
+	initial-role = "primary";
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
+	i2c-scl-hz = <1000000>;
+
+	sbtsi_p1_0: sbtsi@48,22400000001 {
+		reg = <0x48 0x224 0x00000001>;
+		assigned-address = <0x48>;
+	};
+	sbrmi_p1_1: sbrmi@38,22400000002 {
+		reg = <0x38 0x224 0x00000002>;
+		assigned-address = <0x38>;
 	};
 };
 
@@ -414,6 +432,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
+
 	i3c_hub0: i3chub0@70,4CC00000000 {
 		reg = <0x70 0x4CC 0x00000000>;
 		assigned-address = <0x70>;
@@ -439,6 +458,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
+
 	i3c_hub2: i3chub0@70,4CC00000000 {
 		reg = <0x70 0x4CC 0x00000000>;
 		assigned-address = <0x70>;

--- a/drivers/i3c/master/mipi-i3c-hci/core.c
+++ b/drivers/i3c/master/mipi-i3c-hci/core.c
@@ -747,7 +747,9 @@ static int i3c_hci_attach_i3c_dev(struct i3c_dev_desc *dev)
 		return -ENOMEM;
 	if (hci->cmd == &mipi_i3c_hci_cmd_v1) {
 #ifdef CONFIG_ARCH_ASPEED
-		ret = mipi_i3c_hci_dat_v1.alloc_entry(hci, dev->info.dyn_addr);
+		ret = mipi_i3c_hci_dat_v1.alloc_entry(hci,
+			dev->info.dyn_addr ?
+			dev->info.dyn_addr : dev->info.static_addr);
 #else
 		ret = mipi_i3c_hci_dat_v1.alloc_entry(hci);
 #endif
@@ -755,7 +757,9 @@ static int i3c_hci_attach_i3c_dev(struct i3c_dev_desc *dev)
 			kfree(dev_data);
 			return ret;
 		}
-		mipi_i3c_hci_dat_v1.set_dynamic_addr(hci, ret, dev->info.dyn_addr);
+		mipi_i3c_hci_dat_v1.set_dynamic_addr(hci, ret,
+			dev->info.dyn_addr ?
+			dev->info.dyn_addr : dev->info.static_addr);
 		dev_data->dat_idx = ret;
 	}
 	i3c_dev_set_master_data(dev, dev_data);

--- a/drivers/i3c/master/mipi-i3c-hci/core.c
+++ b/drivers/i3c/master/mipi-i3c-hci/core.c
@@ -202,8 +202,12 @@ static void aspeed_i3c_of_populate_bus_timing(struct i3c_hci *hci, struct device
 	core_period = DIV_ROUND_UP(1000000000, core_rate);
 
 	/* Workaround . Need to remove once hardware support is available
-	   for internal LDO powerup support is available. */
-	if (!i3c_device_power) {
+	   for internal LDO powerup support is available. Check for the JESD403
+	   compliance is added to avoid changing the frequency for the i3c buses
+	   like APML on which there are no i3c hub devices. This check can be
+	   removed when hardware support is available for internal LDO powerup.
+	 */
+	if (!i3c_device_power && hci->master.bus.context == I3C_BUS_CONTEXT_JESD403) {
 		hci->master.bus.scl_rate.i3c = 1000000;
 		dev_info(&hci->master.dev, "Updated clock to 1Mhz");
 	}
@@ -471,7 +475,14 @@ static int i3c_hci_send_ccc_cmd(struct i3c_master_controller *m,
 	    ccc->rnw, ccc->dbp, ccc->db, ccc->ndests,
 	    ccc->dests[0].payload.len);
 
-	if (!i3c_device_power) {
+	/*
+	 * Driver should be able to send the CCC commands on the i3c buses like the
+	 * APML/I3C bus on which there is no i3chub device. Following check for
+	 * JESD403 is added so that the driver will not skip sending the CCC commands.
+	 * Once the support of LDO internal powerup from the hardware, the check for
+	 * JESD403 can be removed.
+	 */
+	if (!i3c_device_power && m->bus.context == I3C_BUS_CONTEXT_JESD403) {
 		 dev_info(&hci->master.dev,"User requested to skip CCC commands \n");
 		 return 0;
 	}

--- a/drivers/i3c/master/mipi-i3c-hci/core.c
+++ b/drivers/i3c/master/mipi-i3c-hci/core.c
@@ -777,6 +777,9 @@ static int i3c_hci_reattach_i3c_dev(struct i3c_dev_desc *dev, u8 old_dyn_addr)
 	if (hci->cmd == &mipi_i3c_hci_cmd_v1)
 		mipi_i3c_hci_dat_v1.set_dynamic_addr(hci, dev_data->dat_idx,
 					     dev->info.dyn_addr);
+#ifdef CONFIG_ARCH_ASPEED
+	dev_data->dat_idx = dev->info.dyn_addr;
+#endif
 	return 0;
 }
 

--- a/drivers/i3c/master/mipi-i3c-hci/dat_v1.c
+++ b/drivers/i3c/master/mipi-i3c-hci/dat_v1.c
@@ -103,7 +103,8 @@ static int hci_dat_v1_alloc_entry(struct i3c_hci *hci, unsigned int address)
 	__set_bit(dat_idx, hci->DAT_data);
 
 	/* default flags */
-	dat_w0_write(dat_idx, DAT_0_SIR_REJECT | DAT_0_MR_REJECT);
+	dat_w0_write(dat_idx,
+		DAT_0_DEV_NACK_RETRY_CNT | DAT_0_SIR_REJECT | DAT_0_MR_REJECT);
 
 	return dat_idx;
 }

--- a/drivers/i3c/master/mipi-i3c-hci/dat_v1.c
+++ b/drivers/i3c/master/mipi-i3c-hci/dat_v1.c
@@ -141,6 +141,17 @@ static void hci_dat_v1_free_entry(struct i3c_hci *hci, unsigned int dat_idx)
 static void hci_dat_v1_set_dynamic_addr(struct i3c_hci *hci,
 					unsigned int dat_idx, u8 address)
 {
+#ifdef CONFIG_ARCH_ASPEED
+	if (dat_idx != address) {
+		int ret;
+
+		ret = hci_dat_v1_alloc_entry(hci, address);
+		if (ret < 0) {
+			dev_err(&hci->master.dev, "Allocate entry: %d", ret);
+			hci_dat_v1_free_entry(hci, dat_idx);
+		}
+	}
+#else
 	u32 dat_w0;
 
 	dat_w0 = dat_w0_read(dat_idx);
@@ -148,6 +159,7 @@ static void hci_dat_v1_set_dynamic_addr(struct i3c_hci *hci,
 	dat_w0 |= FIELD_PREP(DAT_0_DYNAMIC_ADDRESS, address) |
 		  (dynaddr_parity(address) ? DAT_0_DYNADDR_PARITY : 0);
 	dat_w0_write(dat_idx, dat_w0);
+#endif
 }
 
 static void hci_dat_v1_set_static_addr(struct i3c_hci *hci,


### PR DESCRIPTION
drivers : i3c : add support for APML i3c bus

Following changes are required to support APML I3C bus on Venice based platforms:
1. configure internal pullups in the device tree
2. set the NACK retry count to max 
3. set the dynamic address with the assigned address for the device allocation to be successful in the device address table

verified : tested on Morocco