### PR TITLE
ARM64 : dts : aspeed : Congo : Add i2c1 bus

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -253,6 +253,10 @@
         };
 };
 
+&i2c1 {
+	status = "okay";
+};
+
 &i2c7 {
 	status = "okay";
         clock-frequency = <400000>;


### PR DESCRIPTION
Add i2c1 bus behind FPGA LTPI interface.

tested: verified on Congo