### PR TITLE
ARM64:dts:aspeed: PRB : remove USB2

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -454,15 +454,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         status = "okay";
 };
 
-&ehci1 {
-	status = "okay";
-};
-
 &usb3ahp {
-        status = "okay";
-};
-
-&phy2a {
         status = "okay";
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -565,18 +565,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 };
 
-&usb2ahp {
-	status = "okay";
-};
-
-&usb2bhp {
-	status = "okay";
-};
-
-&phy2a {
-	status = "okay";
-};
-
 &phy3a {
 	status = "okay";
 };


### PR DESCRIPTION
Remove USB2 from PRB DTS due to A0 silicon issue 
(USB2 does not work and can cause issue during OS Boot)

tested: verified in Nigeria and Kenya platforms

Signed-off-by: Mohsen Dolaty <mohsen.dolaty@amd.com>