### PR TITLE
Congo dts changes

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -462,7 +462,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 
 	sbtsi_p0_0: sbtsi@4c,22400000001 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -174,6 +174,8 @@
 };
 
 &i2c0 {
+        /delete-property/ pinctrl-names;
+        /delete-property/ pinctrl-0;
         status = "okay";
         i2cswitch@70 {
                 compatible = "nxp,pca9548";
@@ -262,6 +264,8 @@
 };
 
 &i2c1 {
+    /delete-property/ pinctrl-names;
+    /delete-property/ pinctrl-0;
 	status = "okay";
 };
 


### PR DESCRIPTION
1.     Remove the pinctrl-related properties for i2c0 and i2c1
        to free up the original physical pins for other functions.
2.      Lower the APML bus frequency from 12.5 Mhz to
       10 Mhz to enable APML in Congo.
