### PR TITLE
mtd: spi-nor: gigadevice: add support for GD25LR512MF

### DIFF
--- a/drivers/mtd/spi-nor/gigadevice.c
+++ b/drivers/mtd/spi-nor/gigadevice.c
@@ -24,7 +24,7 @@ gd25q256_post_bfpt(struct spi_nor *nor,
 	 */
 	if (bfpt_header->major == SFDP_JESD216_MAJOR &&
 	    bfpt_header->minor == SFDP_JESD216_MINOR)
-		nor->params->quad_enable = spi_nor_sr1_bit6_quad_enable;
+		nor->params->quad_enable = spi_nor_sr2_bit1_quad_enable;
 
 	return 0;
 }
@@ -58,6 +58,13 @@ static const struct flash_info gigadevice_nor_parts[] = {
 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
 			      SPI_NOR_QUAD_READ) },
+	{ "gd25lb256", INFO(0xc86019, 0, 64 * 1024, 512)
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
+		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
+			      SPI_NOR_QUAD_READ) },
+	{ "gd25lr512m", INFO(0xc8601a, 0, 64 * 1024, 4096)
+		PARSE_SFDP
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
 	{ "gd25q128", INFO(0xc84018, 0, 64 * 1024, 256)
 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB)
 		NO_SFDP_FLAGS(SECT_4K | SPI_NOR_DUAL_READ |
@@ -67,6 +74,24 @@ static const struct flash_info gigadevice_nor_parts[] = {
 		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB | SPI_NOR_TB_SR_BIT6)
 		FIXUP_FLAGS(SPI_NOR_4B_OPCODES)
 		.fixups = &gd25q256_fixups },
+	{ "gd55b01gf", INFO(0xc8401b, 0, 64 * 1024, 2048)
+		PARSE_SFDP
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
+	{ "gd55b02gf", INFO(0xc8401c, 0, 64 * 1024, 4096)
+		PARSE_SFDP
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
+	{ "gd25b512m", INFO(0xc8471a, 0, 64 * 1024, 1024)
+		PARSE_SFDP
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
+	{ "gd25b512m", INFO(0xc8471a, 0, 64 * 1024, 1024)
+		PARSE_SFDP
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
+	{ "gd55b01ge", INFO(0xc8471b, 0, 64 * 1024, 2048)
+		PARSE_SFDP
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
+	{ "gd55b02ge", INFO(0xc8471c, 0, 64 * 1024, 4096)
+		PARSE_SFDP
+		FLAGS(SPI_NOR_HAS_LOCK | SPI_NOR_HAS_TB) },
 };
 
 const struct spi_nor_manufacturer spi_nor_gigadevice = {


### PR DESCRIPTION
Add support for Gigadevice SPI part GD25LR512MF

Test result on AST2700 controller:
$ cat jedec_id
c8601a

$ cat partname
gd25lr512m

$ hexdump -C sfdp
00000000  53 46 44 50 07 01 03 ff  00 07 01 14 30 00 00 ff  |SFDP........0...| 00000010  c8 00 01 03 90 00 00 ff  84 01 01 02 c0 00 00 ff  |................| 00000020  03 00 01 02 e0 00 00 ff  ff ff ff ff ff ff ff ff  |................| 00000030  e5 20 f3 ff ff ff ff 1f  44 eb 08 6b 08 3b 42 bb  |. ......D..k.;B.| 00000040  fe ff ff ff ff ff 00 ff  ff ff 44 eb 0c 20 0f 52  |..........D.. .R| 00000050  10 d8 00 ff d4 39 a5 fe  82 d8 14 58 ec 62 16 33  |.....9.....X.b.3| 00000060  7a 75 7a 75 04 bd d5 5c  29 80 18 00 08 50 00 01  |zuzu...\)....P..| 00000070  00 00 00 00 00 00 90 00  00 00 00 00 ff ff ff ff  |................| 00000080  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................| 00000090  00 20 50 16 9d f9 77 64  8f db ff ff ff ff ff ff  |. P...wd........| 000000a0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................| *
000000c0  ff 0e 0f fe 21 5c dc ff  ff ff ff ff ff ff ff ff  |....!\..........| 000000d0  ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff  |................|
000000e0  38 9b 96 f0 a6 a5 b0 ff                           |8.......|
000000e8