### PR TITLE
ARM64:dts:aspeed change i2c13 default pinctrl

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
+++ b/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
@@ -2294,7 +2294,7 @@
 		interrupts-extended = <&soc0_intc2 13>;
 		clock-frequency = <100000>;
 		pinctrl-names = "default";
-		pinctrl-0 = <&pinctrl_i2c13_default>;
+		pinctrl-0 = <&pinctrl_di2c13_default>;
 		status = "disabled";
 	};
 


### PR DESCRIPTION
AMD SP7 platform uses DI2C13 default pinctrl instead of I2C13 pinctrl

tested: verified in Morocco platform