### PR TITLE
ARM64 : dts : aspeed : Morocco : enable MCTP over I2C

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -99,6 +99,9 @@
 		i2c133 = &P1_clk;
 		i2c134 = &P1_vr;
 		i2c135 = &NC_14;
+		i2c180 = &p0_pcie_slot0;
+		i2c181 = &p0_pcie_slot1;
+		i2c182 = &p0_pcie_slot2;
 		i2c200 = &picpwr_fan_0;
 		i2c201 = &picpwr_fan_1;
 		i2c202 = &picpwr_pdb;
@@ -225,6 +228,14 @@
 	// Net name SCM_I2C<0>
 	status = "okay";
         clock-frequency = <400000>;
+
+	multi-master;
+	mctp-controller;
+	mctp@10 {
+		compatible = "mctp-i2c-controller";
+		reg = <(0x10 | I2C_OWN_SLAVE_ADDRESS)>;
+	};
+
 	hpmeeprom@50 {
 		compatible = "microchip,24lc256","atmel,24c256";
 		reg = <0x50>;
@@ -252,6 +263,31 @@
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+			i2cswitch@71 {
+				compatible = "nxp,pca9548";
+				reg = <0x71>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				p0_pcie_slot0: i2c@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					mctp-controller;
+				};
+				p0_pcie_slot1: i2c@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					mctp-controller;
+				};
+				p0_pcie_slot2: i2c@2 {
+					reg = <2>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					mctp-controller;
+				};
+			};
 		};
 
 		NC_3: i2c@3 {


### PR DESCRIPTION
Enable MCTP over I2C for the onboard P0 PCIe slots only. The P1 PCIe connections are backplane/Ginger type of add on cards. MCTP i2c configuration is not added for P1 since the MCTP endpoint connectivity depends on the i2c circuitry of these add on boards.

Tested: verified MCTP over I2C on Morocco with Mellanox