### PR TITLE
drivers: misc: inetgrate apml_modules

### DIFF
--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -562,6 +562,14 @@ config TPS6594_PFSM
 	  This driver can also be built as a module.  If so, the module
 	  will be called tps6594-pfsm.
 
+config AMD_APML
+    tristate "AMD APML Driver Support"
+    help
+      Enable support for AMD APML (Advanced Platform Management Link) drivers.
+      This includes modules for SB-RMI, SB-TSI, and AlertL mechanisms.
+
+      If you choose 'M', the driver will be built as modules.
+
 source "drivers/misc/c2port/Kconfig"
 source "drivers/misc/eeprom/Kconfig"
 source "drivers/misc/cb710/Kconfig"

--- a/drivers/misc/Makefile
+++ b/drivers/misc/Makefile
@@ -67,3 +67,4 @@ obj-$(CONFIG_TMR_MANAGER)      += xilinx_tmr_manager.o
 obj-$(CONFIG_TMR_INJECT)	+= xilinx_tmr_inject.o
 obj-$(CONFIG_TPS6594_ESM)	+= tps6594-esm.o
 obj-$(CONFIG_TPS6594_PFSM)	+= tps6594-pfsm.o
+obj-$(CONFIG_AMD_APML)      += apml-modules/


### PR DESCRIPTION
- Added Makefile for APML modules
- The driver implemenst APML alert and SBRMI, SBTSI functionalities
- Includescommon SBRMI functions and headers
- Updated Kconfig and Makefile to include APML modules