### PR TITLE
ARM64:dts:aspeed Add SPI LCD to Morocco DTS

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -188,6 +188,24 @@
 	};
 };
 
+#ifdef LCD_ENABLE
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_spi1_cs1_default>;
+	pinctrl-names = "default";
+	compatible = "aspeed,ast2700-spi-txrx";  // Change the SPI controller driver
+
+	oled@0 {
+		reg = < 0 >; // Chip select 0
+		compatible = "ssd,ssd1322";
+		spi-max-frequency = <1000000>; // Adjust the frequency as needed
+		label = "ssd1322";
+		status = "okay"; // Enable the SSD1322 device
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+#else
 &spi1 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_spi1_cs1_default>;
@@ -202,6 +220,7 @@
 		spi-rx-bus-width = <1>;
 	};
 };
+#endif
 
 //BMC Console
 &uart12 {


### PR DESCRIPTION
Add conditional device tree change for adding spi1 LCD device

tested: verified in Morocco platform