### PR TITLE
drivers: misc: Add SBRMI and SBTSI driver support

### DIFF
--- a/drivers/misc/Kconfig
+++ b/drivers/misc/Kconfig
@@ -562,6 +562,7 @@ config TPS6594_PFSM
 	  This driver can also be built as a module.  If so, the module
 	  will be called tps6594-pfsm.
 
+source "drivers/misc/amd-apml/Kconfig"
 source "drivers/misc/c2port/Kconfig"
 source "drivers/misc/eeprom/Kconfig"
 source "drivers/misc/cb710/Kconfig"

--- a/drivers/misc/Makefile
+++ b/drivers/misc/Makefile
@@ -3,6 +3,7 @@
 # Makefile for misc devices that really don't fit anywhere else.
 #
 
+obj-$(CONFIG_APML_SBRMI)	+= amd-apml/
 obj-$(CONFIG_IBM_ASM)		+= ibmasm/
 obj-$(CONFIG_IBMVMC)		+= ibmvmc.o
 obj-$(CONFIG_AD525X_DPOT)	+= ad525x_dpot.o

--- a/drivers/misc/Makefile
+++ b/drivers/misc/Makefile
@@ -3,7 +3,7 @@
 # Makefile for misc devices that really don't fit anywhere else.
 #
 
-obj-$(CONFIG_APML_SBRMI)	+= amd-apml/
+obj-$(or $(CONFIG_APML_SBRMI),$(CONFIG_APML_SBTSI)) += amd-apml/
 obj-$(CONFIG_IBM_ASM)		+= ibmasm/
 obj-$(CONFIG_IBMVMC)		+= ibmvmc.o
 obj-$(CONFIG_AD525X_DPOT)	+= ad525x_dpot.o

--- a/drivers/misc/amd-apml/Kconfig
+++ b/drivers/misc/amd-apml/Kconfig
@@ -13,3 +13,14 @@ config APML_SBRMI
 
       This driver can also be built as a module. If so, the module will
       be called apml_sbrmi.
+
+config APML_SBTSI
+    tristate "Emulated SB-TSI interface driver over i3c bus"
+    depends on I3C && !SENSORS_SBTSI
+    select REGMAP_I3C if I3C
+    help
+      If you say yes here you get support for emulated TSI
+      interface on AMD SoCs with APML interface connected to a BMC device.
+
+      This driver can also be built as a module. If so, the module will
+      be called apml_sbtsi.

--- a/drivers/misc/amd-apml/Kconfig
+++ b/drivers/misc/amd-apml/Kconfig
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# AMD APML BMC interface drivers
+#
+
+config APML_SBRMI
+    tristate "Emulated SB-RMI interface driver over i3c bus"
+    depends on I3C && !SENSORS_SBRMI
+    select REGMAP_I3C if I3C
+    help
+      If you say yes here you get support for emulated RMI
+      interface on AMD SoCs with APML interface connected to a BMC device.
+
+      This driver can also be built as a module. If so, the module will
+      be called apml_sbrmi.

--- a/drivers/misc/amd-apml/Makefile
+++ b/drivers/misc/amd-apml/Makefile
@@ -5,3 +5,4 @@
 #
 
 obj-$(CONFIG_APML_SBRMI)	+= sbrmi.o sbrmi-common.o
+obj-$(CONFIG_APML_SBTSI)	+= apml_sbtsi.o

--- a/drivers/misc/amd-apml/Makefile
+++ b/drivers/misc/amd-apml/Makefile
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Makefile for linux/drivers/platform/x86/amd-apml
+# AMD APML BMC interface drivers
+#
+
+obj-$(CONFIG_APML_SBRMI)	+= sbrmi.o sbrmi-common.o

--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * apml_sbtsi.c - hwmon driver for a SBI Temperature Sensor Interface (SB-TSI)
+ *                compliant AMD SoC temperature device.
+ * 		   Also register to misc driver with an IOCTL.
+ *
+ * Copyright (c) 2020, Google Inc.
+ * Copyright (c) 2020, Kun Yi <kunyi@google.com>
+ * Copyright (C) 2022 Advanced Micro Devices, Inc.
+ */
+
+#include <linux/err.h>
+#include <linux/fs.h>
+#include <linux/hwmon.h>
+#include <linux/i3c/device.h>
+#include <linux/i3c/master.h>
+#include <linux/init.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/minmax.h>
+#include <linux/mutex.h>
+#include <linux/of_device.h>
+#include <linux/of.h>
+#include <linux/regmap.h>
+#include <linux/version.h>
+
+#include <linux/amd-apml.h>
+
+/*
+ * SB-TSI registers only support SMBus byte data access. "_INT" registers are
+ * the integer part of a temperature value or limit, and "_DEC" registers are
+ * corresponding decimal parts.
+ */
+#define SBTSI_REG_TEMP_INT		0x01 /* RO */
+#define SBTSI_REG_STATUS		0x02 /* RO */
+#define SBTSI_REG_CONFIG		0x03 /* RO */
+#define SBTSI_REG_TEMP_HIGH_INT		0x07 /* RW */
+#define SBTSI_REG_TEMP_LOW_INT		0x08 /* RW */
+#define SBTSI_REG_TEMP_DEC		0x10 /* RW */
+#define SBTSI_REG_TEMP_HIGH_DEC		0x13 /* RW */
+#define SBTSI_REG_TEMP_LOW_DEC		0x14 /* RW */
+
+#define SBTSI_CONFIG_READ_ORDER_SHIFT	5
+
+#define SBTSI_TEMP_MIN	0
+#define SBTSI_TEMP_MAX	255875
+
+/*
+ * SBTSI_STEP_INC Fractional portion of temperature
+ * One increment of these bits is equivalent to a step of 0.125 °C
+ *
+ * SBTSI_INT_OFFSET Integer offset for temperature value
+ *
+ * SBTSI_DEC_OFFSET offset for decimal bits in register[7:5]
+ *
+ * SBTSI_DEC_MASK Mask for decimal value
+ */
+#define SBTSI_STEP_INC		125
+#define SBTSI_INT_OFFSET	3
+#define SBTSI_DEC_OFFSET	5
+#define SBTSI_DEC_MASK		0x7
+
+struct apml_sbtsi_device {
+	struct miscdevice sbtsi_misc_dev;
+	struct regmap *regmap;
+	struct mutex lock;
+	u8 dev_static_addr;
+} __packed;
+
+/*
+ * From SB-TSI spec: CPU temperature readings and limit registers encode the
+ * temperature in increments of 0.125 from 0 to 255.875. The "high byte"
+ * register encodes the base-2 of the integer portion, and the upper 3 bits of
+ * the "low byte" encode in base-2 the decimal portion.
+ *
+ * e.g. INT=0x19, DEC=0x20 represents 25.125 degrees Celsius
+ *
+ * Therefore temperature in millidegree Celsius =
+ *   (INT + DEC / 256) * 1000 = (INT * 8 + DEC / 32) * 125
+ */
+static inline int sbtsi_reg_to_mc(s32 integer, s32 decimal)
+{
+	return ((integer << SBTSI_INT_OFFSET) +
+	       (decimal >> SBTSI_DEC_OFFSET)) * SBTSI_STEP_INC;
+}
+
+/*
+ * Inversely, given temperature in millidegree Celsius
+ *   INT = (TEMP / 125) / 8
+ *   DEC = ((TEMP / 125) % 8) * 32
+ * Caller have to make sure temp doesn't exceed 255875, the max valid value.
+ */
+static inline void sbtsi_mc_to_reg(s32 temp, u8 *integer, u8 *decimal)
+{
+	temp /= SBTSI_STEP_INC;
+	*integer = temp >> SBTSI_INT_OFFSET;
+	*decimal = (temp & SBTSI_DEC_MASK) << SBTSI_DEC_OFFSET;
+}
+
+static int sbtsi_read(struct device *dev, enum hwmon_sensor_types type,
+		      u32 attr, int channel, long *val)
+{
+	struct apml_sbtsi_device *tsi_dev = dev_get_drvdata(dev);
+	unsigned int temp_int, temp_dec, cfg;
+	int ret;
+
+	switch (attr) {
+	case hwmon_temp_input:
+		/*
+		 * ReadOrder bit specifies the reading order of integer and
+		 * decimal part of CPU temp for atomic reads. If bit == 0,
+		 * reading integer part triggers latching of the decimal part,
+		 * so integer part should be read first. If bit == 1, read
+		 * order should be reversed.
+		 */
+		ret = regmap_read(tsi_dev->regmap, SBTSI_REG_CONFIG, &cfg);
+		if (ret < 0)
+			return ret;
+
+		mutex_lock(&tsi_dev->lock);
+		if (cfg & BIT(SBTSI_CONFIG_READ_ORDER_SHIFT)) {
+			ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_DEC, &temp_dec);
+			ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_INT, &temp_int);
+		} else {
+			ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_INT, &temp_int);
+			ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_DEC, &temp_dec);
+		}
+		mutex_unlock(&tsi_dev->lock);
+		break;
+	case hwmon_temp_max:
+		mutex_lock(&tsi_dev->lock);
+		ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_HIGH_INT, &temp_int);
+		ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_HIGH_DEC, &temp_dec);
+		mutex_unlock(&tsi_dev->lock);
+		break;
+	case hwmon_temp_min:
+		mutex_lock(&tsi_dev->lock);
+		ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_LOW_INT, &temp_int);
+		ret = regmap_read(tsi_dev->regmap, SBTSI_REG_TEMP_LOW_DEC, &temp_dec);
+		mutex_unlock(&tsi_dev->lock);
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	if (ret < 0)
+		return ret;
+
+	*val = sbtsi_reg_to_mc(temp_int, temp_dec);
+
+	return 0;
+}
+
+static int sbtsi_write(struct device *dev, enum hwmon_sensor_types type,
+		       u32 attr, int channel, long val)
+{
+	struct apml_sbtsi_device *tsi_dev = dev_get_drvdata(dev);
+	unsigned int temp_int, temp_dec;
+	int reg_int, reg_dec, err;
+
+	switch (attr) {
+	case hwmon_temp_max:
+		reg_int = SBTSI_REG_TEMP_HIGH_INT;
+		reg_dec = SBTSI_REG_TEMP_HIGH_DEC;
+		break;
+	case hwmon_temp_min:
+		reg_int = SBTSI_REG_TEMP_LOW_INT;
+		reg_dec = SBTSI_REG_TEMP_LOW_DEC;
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	val = clamp_val(val, SBTSI_TEMP_MIN, SBTSI_TEMP_MAX);
+	sbtsi_mc_to_reg(val, (u8 *)&temp_int, (u8 *)&temp_dec);
+
+	mutex_lock(&tsi_dev->lock);
+	err = regmap_write(tsi_dev->regmap, reg_int, temp_int);
+	if (err)
+		goto exit;
+
+	err = regmap_write(tsi_dev->regmap, reg_dec, temp_dec);
+exit:
+	mutex_unlock(&tsi_dev->lock);
+	return err;
+}
+
+static umode_t sbtsi_is_visible(const void *data,
+				enum hwmon_sensor_types type,
+				u32 attr, int channel)
+{
+	switch (type) {
+	case hwmon_temp:
+		switch (attr) {
+		case hwmon_temp_input:
+			return 0444;
+		case hwmon_temp_min:
+			return 0644;
+		case hwmon_temp_max:
+			return 0644;
+		}
+		break;
+	default:
+		break;
+	}
+	return 0;
+}
+
+static const struct hwmon_channel_info *sbtsi_info[] = {
+	HWMON_CHANNEL_INFO(chip, HWMON_C_REGISTER_TZ),
+	HWMON_CHANNEL_INFO(temp, HWMON_T_INPUT | HWMON_T_MIN | HWMON_T_MAX),
+	NULL
+};
+
+static const struct hwmon_ops sbtsi_hwmon_ops = {
+	.is_visible = sbtsi_is_visible,
+	.read = sbtsi_read,
+	.write = sbtsi_write,
+};
+
+static const struct hwmon_chip_info sbtsi_chip_info = {
+	.ops = &sbtsi_hwmon_ops,
+	.info = sbtsi_info,
+};
+
+static long sbtsi_ioctl(struct file *fp, unsigned int cmd, unsigned long arg)
+{
+	int __user *arguser = (int  __user *)arg;
+	struct apml_message msg = { 0 };
+	struct apml_sbtsi_device *tsi_dev;
+	int ret;
+
+	if (copy_struct_from_user(&msg, sizeof(msg), arguser, sizeof(struct apml_message)))
+		return -EFAULT;
+
+	if (msg.cmd != APML_REG)
+		return -EINVAL;
+
+	tsi_dev = container_of(fp->private_data, struct apml_sbtsi_device, sbtsi_misc_dev);
+	if (!tsi_dev)
+		return -EFAULT;
+
+	mutex_lock(&tsi_dev->lock);
+
+	if (!msg.data_in.reg_in[RD_FLAG_INDEX]) {
+		ret = regmap_write(tsi_dev->regmap,
+				   msg.data_in.reg_in[REG_OFF_INDEX],
+				   msg.data_in.reg_in[REG_VAL_INDEX]);
+	} else {
+		ret = regmap_read(tsi_dev->regmap,
+				  msg.data_in.reg_in[REG_OFF_INDEX],
+				  (int *)&msg.data_out.reg_out[RD_WR_DATA_INDEX]);
+		if (ret)
+			goto out;
+
+		if (copy_to_user(arguser, &msg, sizeof(struct apml_message)))
+			ret = -EFAULT;
+	}
+out:
+	mutex_unlock(&tsi_dev->lock);
+	return ret;
+}
+
+static const struct file_operations sbtsi_fops = {
+	.owner		= THIS_MODULE,
+	.unlocked_ioctl	= sbtsi_ioctl,
+	.compat_ioctl	= sbtsi_ioctl,
+};
+
+static int create_misc_tsi_device(struct apml_sbtsi_device *tsi_dev,
+				  struct device *dev)
+{
+	int ret;
+
+	tsi_dev->sbtsi_misc_dev.name		= devm_kasprintf(dev, GFP_KERNEL,
+						  "sbtsi-%x", tsi_dev->dev_static_addr);
+	tsi_dev->sbtsi_misc_dev.minor		= MISC_DYNAMIC_MINOR;
+	tsi_dev->sbtsi_misc_dev.fops		= &sbtsi_fops;
+	tsi_dev->sbtsi_misc_dev.parent		= dev;
+	tsi_dev->sbtsi_misc_dev.nodename	= devm_kasprintf(dev, GFP_KERNEL,
+						  "sbtsi-%x", tsi_dev->dev_static_addr);
+	tsi_dev->sbtsi_misc_dev.mode		= 0600;
+
+	ret = misc_register(&tsi_dev->sbtsi_misc_dev);
+	if (ret)
+		return ret;
+
+	dev_info(dev, "register %s device\n", tsi_dev->sbtsi_misc_dev.name);
+	return ret;
+}
+
+static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
+{
+	struct device *dev = &i3cdev->dev;
+	struct device *hwmon_dev;
+	struct apml_sbtsi_device *tsi_dev;
+	struct regmap_config sbtsi_i3c_regmap_config = {
+		.reg_bits = 8,
+		.val_bits = 8,
+	};
+	struct regmap *regmap;
+
+	dev_info(dev, "SBTSI: PID: %llx\n", i3cdev->desc->info.pid);
+	if (!(i3cdev->desc->info.pid == 0x0 || i3cdev->desc->info.pid == 0x22400000001))
+		return -ENXIO;
+
+	regmap = devm_regmap_init_i3c(i3cdev, &sbtsi_i3c_regmap_config);
+	if (IS_ERR(regmap)) {
+		dev_err(&i3cdev->dev, "Failed to register i3c regmap %d\n",
+			(int)PTR_ERR(regmap));
+		return PTR_ERR(regmap);
+	}
+
+	tsi_dev = devm_kzalloc(dev, sizeof(struct apml_sbtsi_device), GFP_KERNEL);
+	if (!tsi_dev)
+		return -ENOMEM;
+
+	tsi_dev->regmap = regmap;
+	mutex_init(&tsi_dev->lock);
+
+	dev_set_drvdata(dev, (void *)tsi_dev);
+	hwmon_dev = devm_hwmon_device_register_with_info(dev, "sbtsi_i3c", tsi_dev,
+							 &sbtsi_chip_info, NULL);
+
+	if (!hwmon_dev)
+		return PTR_ERR_OR_ZERO(hwmon_dev);
+
+	/* Need to verify for the static address for i3cdev */
+	tsi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
+
+	return create_misc_tsi_device(tsi_dev, dev);
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+static int sbtsi_i2c_probe(struct i2c_client *client,
+			   const struct i2c_device_id *tsi_id)
+#else
+static int sbtsi_i2c_probe(struct i2c_client *client)
+#endif
+{
+	struct device *dev = &client->dev;
+	struct device *hwmon_dev;
+	struct apml_sbtsi_device *tsi_dev;
+	struct regmap_config sbtsi_i2c_regmap_config = {
+		.reg_bits = 8,
+		.val_bits = 8,
+	};
+
+	tsi_dev = devm_kzalloc(dev, sizeof(struct apml_sbtsi_device), GFP_KERNEL);
+	if (!tsi_dev)
+		return -ENOMEM;
+
+	mutex_init(&tsi_dev->lock);
+	tsi_dev->regmap = devm_regmap_init_i2c(client, &sbtsi_i2c_regmap_config);
+	if (IS_ERR(tsi_dev->regmap))
+		return PTR_ERR(tsi_dev->regmap);
+
+	dev_set_drvdata(dev, (void *)tsi_dev);
+
+	hwmon_dev = devm_hwmon_device_register_with_info(dev, client->name,
+							 tsi_dev,
+							 &sbtsi_chip_info,
+							 NULL);
+
+	if (!hwmon_dev)
+		return PTR_ERR_OR_ZERO(hwmon_dev);
+
+	tsi_dev->dev_static_addr = client->addr;
+
+	return create_misc_tsi_device(tsi_dev, dev);
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+static int sbtsi_i3c_remove(struct i3c_device *i3cdev)
+#else
+static void sbtsi_i3c_remove(struct i3c_device *i3cdev)
+#endif
+{
+	struct apml_sbtsi_device *tsi_dev = dev_get_drvdata(&i3cdev->dev);
+
+	if (tsi_dev)
+		misc_deregister(&tsi_dev->sbtsi_misc_dev);
+
+	dev_info(&i3cdev->dev, "Removed sbtsi-i3c driver\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+	return 0;
+#endif
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int sbtsi_i2c_remove(struct i2c_client *client)
+#else
+static void sbtsi_i2c_remove(struct i2c_client *client)
+#endif
+{
+	struct apml_sbtsi_device *tsi_dev = dev_get_drvdata(&client->dev);
+
+	if (tsi_dev)
+		misc_deregister(&tsi_dev->sbtsi_misc_dev);
+
+	dev_info(&client->dev, "Removed sbtsi driver\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	return 0;
+#endif
+}
+
+static const struct i3c_device_id sbtsi_i3c_id[] = {
+	I3C_DEVICE_EXTRA_INFO(0x112, 0, 0x1, NULL),
+	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
+	{}
+};
+MODULE_DEVICE_TABLE(i3c, sbtsi_i3c_id);
+
+static struct i3c_driver sbtsi_i3c_driver = {
+	.driver = {
+		.name = "sbtsi_i3c",
+	},
+	.probe = sbtsi_i3c_probe,
+	.remove = sbtsi_i3c_remove,
+	.id_table = sbtsi_i3c_id,
+};
+
+static const struct i2c_device_id sbtsi_id[] = {
+	{"sbtsi", 0},
+	{}
+};
+MODULE_DEVICE_TABLE(i2c, sbtsi_id);
+
+static const struct of_device_id __maybe_unused sbtsi_of_match[] = {
+	{
+		.compatible = "amd,sbtsi",
+	},
+	{ },
+};
+MODULE_DEVICE_TABLE(of, sbtsi_of_match);
+
+static struct i2c_driver sbtsi_driver = {
+	.class = I2C_CLASS_HWMON,
+	.driver = {
+		.name = "sbtsi",
+		.of_match_table = of_match_ptr(sbtsi_of_match),
+	},
+	.probe = sbtsi_i2c_probe,
+	.remove = sbtsi_i2c_remove,
+	.id_table = sbtsi_id,
+};
+
+module_i3c_i2c_driver(sbtsi_i3c_driver, &sbtsi_driver)
+
+MODULE_AUTHOR("Kun Yi <kunyi@google.com>");
+MODULE_DESCRIPTION("Hwmon driver for AMD SB-TSI emulated sensor");
+MODULE_LICENSE("GPL");

--- a/drivers/misc/amd-apml/sbrmi-common.c
+++ b/drivers/misc/amd-apml/sbrmi-common.c
@@ -1,0 +1,501 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * sbrmi-common.c - file defining SB-RMI protocols
+ *		    compliant AMD SoC device.
+ *
+ * Copyright (C) 2021-2022 Advanced Micro Devices, Inc.
+ */
+#include <linux/err.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/regmap.h>
+
+#include "sbrmi-common.h"
+
+/* Mask for Status Register bit[1] */
+#define SW_ALERT_MASK	0x2
+/* Mask to check H/W Alert status bit */
+#define HW_ALERT_MASK	0x80
+
+/* Software Interrupt for triggering */
+#define START_CMD	0x80
+#define TRIGGER_MAILBOX	0x01
+
+/* Mailbox error with additional data */
+#define ERR_WITH_DATA	0x5
+
+/* Default message lengths as per APML command protocol */
+/* MSR */
+#define MSR_RD_REG_LEN		0xa
+#define MSR_WR_REG_LEN		0x8
+#define MSR_WR_REG_LEN_v21	0x9
+#define MSR_RD_DATA_LEN		0x8
+#define MSR_WR_DATA_LEN		0x7
+#define MSR_WR_DATA_LEN_v21	0x8
+/* CPUID */
+#define CPUID_RD_DATA_LEN	0x8
+#define CPUID_WR_DATA_LEN	0x8
+#define CPUID_WR_DATA_LEN_v21	0x9
+#define CPUID_RD_REG_LEN	0xa
+#define CPUID_WR_REG_LEN	0x9
+#define CPUID_WR_REG_LEN_v21	0xa
+
+/* CPUID MSR Command Ids */
+#define CPUID_MCA_CMD	0x73
+#define RD_CPUID_CMD	0x91
+#define RD_MCA_CMD	0x86
+
+/* SB-RMI registers */
+enum sbrmi_reg {
+	SBRMI_REV		= 0x0,
+	SBRMI_CTRL		= 0x01,
+	SBRMI_STATUS,
+	SBRMI_OUTBNDMSG0	= 0x30,
+	SBRMI_OUTBNDMSG1,
+	SBRMI_OUTBNDMSG2,
+	SBRMI_OUTBNDMSG3,
+	SBRMI_OUTBNDMSG4,
+	SBRMI_OUTBNDMSG5,
+	SBRMI_OUTBNDMSG6,
+	SBRMI_OUTBNDMSG7,
+	SBRMI_INBNDMSG0,
+	SBRMI_INBNDMSG1,
+	SBRMI_INBNDMSG2,
+	SBRMI_INBNDMSG3,
+	SBRMI_INBNDMSG4,
+	SBRMI_INBNDMSG5,
+	SBRMI_INBNDMSG6,
+	SBRMI_INBNDMSG7,
+	SBRMI_SW_INTERRUPT,
+	SBRMI_THREAD128CS	= 0x4b,
+};
+
+/* input for bulk write to v21 of CPUID and MSR protocol */
+struct cpu_msr_indata_v21 {
+	u8 wr_len;	/* const value */
+	u8 rd_len;	/* const value */
+	u8 proto_cmd;	/* const value */
+	u16 thread;	/* thread number */
+	union {
+		u8 reg_offset[4];	/* input value */
+		u32 value;
+	};
+	u8 ext; /* extended function */
+} __packed;
+
+/* input for bulk write to v20 of CPUID and MSR protocol */
+struct cpu_msr_indata {
+	u8 wr_len;	/* const value */
+	u8 rd_len;	/* const value */
+	u8 proto_cmd;	/* const value */
+	u8 thread;	/* thread number */
+	union {
+		u8 reg_offset[4];	/* input value */
+		u32 value;
+	};
+	u8 ext; /* extended function */
+} __packed;
+
+/* output for bulk read from CPUID and MSR protocol */
+struct cpu_msr_outdata {
+	u8 num_bytes;	/* number of bytes return */
+	u8 status;	/* Protocol status code */
+	union {
+		u64 value;
+		u8 reg_data[8];
+	};
+} __packed;
+
+#define prepare_mca_msr_input_message(input, thread_id, data_in, wr_data_len)	\
+	input.rd_len = MSR_RD_DATA_LEN,					\
+	input.wr_len = wr_data_len,					\
+	input.proto_cmd = RD_MCA_CMD,					\
+	input.thread = thread_id << 1,					\
+	input.value =  data_in
+
+#define prepare_cpuid_input_message(input, thread_id, func, ext_func, wr_data_len)	\
+	input.rd_len = CPUID_RD_DATA_LEN,				\
+	input.wr_len = wr_data_len,				\
+	input.proto_cmd = RD_CPUID_CMD,					\
+	input.thread = thread_id << 1,					\
+	input.value =  func,						\
+	input.ext =  ext_func
+
+static int sbrmi_get_rev(struct apml_sbrmi_device *rmi_dev)
+{
+	struct apml_message msg = { 0 };
+	int ret;
+
+	msg.data_in.reg_in[REG_OFF_INDEX] = SBRMI_REV;
+	msg.data_in.reg_in[RD_FLAG_INDEX] = 1;
+	ret = regmap_read(rmi_dev->regmap,
+			  msg.data_in.reg_in[REG_OFF_INDEX],
+			  &msg.data_out.mb_out[RD_WR_DATA_INDEX]);
+	if (ret < 0)
+		return ret;
+
+	rmi_dev->rev = msg.data_out.reg_out[RD_WR_DATA_INDEX];
+	return 0;
+}
+
+/*
+ * For Mailbox command software alert status bit is set by firmware
+ * to indicate command completion
+ * For RMI Rev 0x20, new h/w status bit is introduced. which is used
+ * by firmware to indicate completion of commands (0x71, 0x72, 0x73).
+ * wait for the status bit to be set by the firmware before
+ * reading the data out.
+ */
+static int sbrmi_wait_status(struct apml_sbrmi_device *rmi_dev,
+			     int *status, int mask)
+{
+	int ret, retry = 100;
+
+	do {
+		ret = regmap_read(rmi_dev->regmap, SBRMI_STATUS, status);
+		if (ret < 0)
+			return ret;
+
+		if (*status & mask)
+			break;
+
+		/* Wait 1~2 second for firmware to return data out */
+		if (retry > 95)
+			usleep_range(50, 100);
+		else
+			usleep_range(10000, 20000);
+	} while (retry--);
+
+	if (retry < 0)
+		ret = -ETIMEDOUT;
+	return ret;
+}
+
+static int msr_datain_v20(struct apml_sbrmi_device *rmi_dev,
+			  struct apml_message *msg)
+{
+	struct cpu_msr_indata input = {0};
+	int ret, val = 0;
+	u16 thread;
+
+	thread = msg->data_in.reg_in[THREAD_LOW_INDEX] |
+		 msg->data_in.reg_in[THREAD_HI_INDEX] << 8;
+
+	/* Thread > 127, Thread128 CS register, 1'b1 needs to be set to 1 */
+	if (thread > 127) {
+		thread -= 128;
+		val = 1;
+	}
+	ret = regmap_write(rmi_dev->regmap, SBRMI_THREAD128CS, val);
+	if (ret < 0)
+		return ret;
+
+	prepare_mca_msr_input_message(input, thread,
+				      msg->data_in.mb_in[RD_WR_DATA_INDEX],
+				      MSR_WR_DATA_LEN);
+
+	ret = regmap_bulk_write(rmi_dev->regmap, CPUID_MCA_CMD,
+				&input, MSR_WR_REG_LEN);
+	return ret;
+}
+
+static int msr_datain_v21(struct apml_sbrmi_device *rmi_dev,
+				struct apml_message *msg)
+{
+	struct cpu_msr_indata_v21 input = {0};
+	int ret;
+	u16 thread;
+
+	thread = msg->data_in.reg_in[THREAD_LOW_INDEX] |
+		 msg->data_in.reg_in[THREAD_HI_INDEX] << 8;
+
+	prepare_mca_msr_input_message(input, thread,
+				      msg->data_in.mb_in[RD_WR_DATA_INDEX],
+				      MSR_WR_DATA_LEN_v21);
+
+	ret = regmap_bulk_write(rmi_dev->regmap, CPUID_MCA_CMD,
+				&input, MSR_WR_REG_LEN_v21);
+	return ret;
+}
+
+/* MCA MSR protocol */
+int rmi_mca_msr_read(struct apml_sbrmi_device *rmi_dev,
+		     struct apml_message *msg)
+{
+	struct cpu_msr_outdata output = {0};
+	int ret;
+	int hw_status;
+
+	if (!rmi_dev->regmap)
+		return ENODEV;
+
+	/* cache the rev value to identify if protocol is supported or not */
+	if (!rmi_dev->rev) {
+		ret = sbrmi_get_rev(rmi_dev);
+		if (ret < 0)
+			return ret;
+	}
+
+	switch(rmi_dev->rev) {
+	/* MCA MSR protocol for REV 0x10 is not supported*/
+	case 0x10:
+		return -EOPNOTSUPP;
+	case 0x20:
+		ret = msr_datain_v20(rmi_dev, msg);
+		if (ret < 0)
+			goto exit_unlock;
+
+		break;
+	case 0x21:
+		ret = msr_datain_v21(rmi_dev, msg);
+		if (ret < 0)
+			goto exit_unlock;
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	ret = sbrmi_wait_status(rmi_dev, &hw_status, HW_ALERT_MASK);
+	if (ret < 0)
+		goto exit_unlock;
+
+	ret = regmap_bulk_read(rmi_dev->regmap, CPUID_MCA_CMD,
+			       &output, MSR_RD_REG_LEN);
+	if (ret < 0)
+		goto exit_unlock;
+
+	ret = regmap_write(rmi_dev->regmap, SBRMI_STATUS,
+			   HW_ALERT_MASK);
+	if (ret < 0)
+		goto exit_unlock;
+
+	if (output.num_bytes != MSR_RD_REG_LEN - 1) {
+		ret = -EMSGSIZE;
+		goto exit_unlock;
+	}
+	if (output.status) {
+		ret = -EPROTOTYPE;
+		msg->fw_ret_code = output.status;
+		goto exit_unlock;
+	}
+	msg->data_out.cpu_msr_out = output.value;
+
+exit_unlock:
+	return ret;
+}
+
+static int cpuid_datain_v20(struct apml_sbrmi_device *rmi_dev,
+			    struct apml_message *msg)
+{
+	struct cpu_msr_indata input = {0};
+	int ret, val = 0;
+	u16 thread;
+
+	thread = msg->data_in.reg_in[THREAD_LOW_INDEX] |
+		 msg->data_in.reg_in[THREAD_HI_INDEX] << 8;
+
+	/* Thread > 127, Thread128 CS register, 1'b1 needs to be set to 1 */
+	if (thread > 127) {
+		thread -= 128;
+		val = 1;
+	}
+	ret = regmap_write(rmi_dev->regmap, SBRMI_THREAD128CS, val);
+	if (ret < 0)
+		return ret;
+	prepare_cpuid_input_message(input, thread,
+				    msg->data_in.mb_in[RD_WR_DATA_INDEX],
+				    msg->data_in.reg_in[EXT_FUNC_INDEX],
+				    CPUID_WR_DATA_LEN);
+
+	ret = regmap_bulk_write(rmi_dev->regmap, CPUID_MCA_CMD,
+				&input, CPUID_WR_REG_LEN);
+	return ret;
+}
+
+static int cpuid_datain_v21(struct apml_sbrmi_device *rmi_dev,
+			    struct apml_message *msg)
+{
+	struct cpu_msr_indata_v21 input = {0};
+	int ret;
+	u16 thread;
+
+	thread = msg->data_in.reg_in[THREAD_LOW_INDEX] |
+		 msg->data_in.reg_in[THREAD_HI_INDEX] << 8;
+
+	prepare_cpuid_input_message(input, thread,
+				    msg->data_in.mb_in[RD_WR_DATA_INDEX],
+				    msg->data_in.reg_in[EXT_FUNC_INDEX],
+				    CPUID_WR_DATA_LEN_v21);
+
+	ret = regmap_bulk_write(rmi_dev->regmap, CPUID_MCA_CMD,
+				&input, CPUID_WR_REG_LEN_v21);
+	return ret;
+}
+
+/* CPUID protocol */
+int rmi_cpuid_read(struct apml_sbrmi_device *rmi_dev,
+		   struct apml_message *msg)
+{
+	struct cpu_msr_outdata output = {0};
+	int ret, hw_status;
+
+	if (!rmi_dev->regmap)
+		return ENODEV;
+
+	/* cache the rev value to identify if protocol is supported or not */
+	if (!rmi_dev->rev) {
+		ret = sbrmi_get_rev(rmi_dev);
+		if (ret < 0)
+			return ret;
+	}
+
+	switch(rmi_dev->rev) {
+	/* CPUID protocol for REV 0x10 is not supported*/
+	case 0x10:
+		return -EOPNOTSUPP;
+	case 0x20:
+		ret = cpuid_datain_v20(rmi_dev, msg);
+		if (ret < 0)
+			goto exit_unlock;
+		break;
+	case 0x21:
+		ret = cpuid_datain_v21(rmi_dev, msg);
+		if (ret < 0)
+			goto exit_unlock;
+		break;
+	default:
+		return -EOPNOTSUPP;
+	}
+
+	ret = sbrmi_wait_status(rmi_dev, &hw_status, HW_ALERT_MASK);
+	if (ret < 0)
+		goto exit_unlock;
+
+	ret = regmap_bulk_read(rmi_dev->regmap, CPUID_MCA_CMD,
+			       &output, CPUID_RD_REG_LEN);
+	if (ret < 0)
+		goto exit_unlock;
+
+	ret = regmap_write(rmi_dev->regmap, SBRMI_STATUS,
+			   HW_ALERT_MASK);
+	if (ret < 0)
+		goto exit_unlock;
+
+	if (output.num_bytes != CPUID_RD_REG_LEN - 1) {
+		ret = -EMSGSIZE;
+		goto exit_unlock;
+	}
+	if (output.status) {
+		ret = -EPROTOTYPE;
+		msg->fw_ret_code = output.status;
+		goto exit_unlock;
+	}
+	msg->data_out.cpu_msr_out = output.value;
+exit_unlock:
+	return ret;
+}
+
+static int esmi_oob_clear_status_alert(struct apml_sbrmi_device *rmi_dev)
+{
+	int sw_status, ret;
+
+	ret = regmap_read(rmi_dev->regmap, SBRMI_STATUS,
+			  &sw_status);
+	if (ret < 0)
+		return ret;
+
+	if (!(sw_status & SW_ALERT_MASK))
+		return 0;
+
+	return regmap_write(rmi_dev->regmap, SBRMI_STATUS,
+			    SW_ALERT_MASK);
+}
+
+int rmi_mailbox_xfer(struct apml_sbrmi_device *rmi_dev,
+		     struct apml_message *msg)
+{
+	unsigned int bytes = 0, ec = 0;
+	int i, ret;
+	int sw_status;
+	u8 byte = 0;
+
+	if (!rmi_dev->regmap)
+		return ENODEV;
+
+	msg->fw_ret_code = 0;
+
+	ret = esmi_oob_clear_status_alert(rmi_dev);
+	if (ret < 0)
+		goto exit_unlock;
+
+	/* Indicate firmware a command is to be serviced */
+	ret = regmap_write(rmi_dev->regmap, SBRMI_INBNDMSG7, START_CMD);
+	if (ret < 0)
+		goto exit_unlock;
+
+	/* Write the command to SBRMI::InBndMsg_inst0 */
+	ret = regmap_write(rmi_dev->regmap, SBRMI_INBNDMSG0, msg->cmd);
+	if (ret < 0)
+		goto exit_unlock;
+
+	/*
+	 * For both read and write the initiator (BMC) writes
+	 * Command Data In[31:0] to SBRMI::InBndMsg_inst[4:1]
+	 * SBRMI_x3C(MSB):SBRMI_x39(LSB)
+	 */
+	for (i = 0; i < MB_DATA_SIZE; i++) {
+		byte = msg->data_in.reg_in[i];
+		ret = regmap_write(rmi_dev->regmap, SBRMI_INBNDMSG1 + i, byte);
+		if (ret < 0)
+			goto exit_unlock;
+	}
+
+	/*
+	 * Write 0x01 to SBRMI::SoftwareInterrupt to notify firmware to
+	 * perform the requested read or write command
+	 */
+	ret = regmap_write(rmi_dev->regmap, SBRMI_SW_INTERRUPT, TRIGGER_MAILBOX);
+	if (ret)
+		goto exit_unlock;
+
+	/*
+	 * Firmware will write SBRMI::Status[SwAlertSts]=1 to generate
+	 * an ALERT (if enabled) to initiator (BMC) to indicate completion
+	 * of the requested command
+	 */
+	ret = sbrmi_wait_status(rmi_dev, &sw_status, SW_ALERT_MASK);
+	if (ret)
+		goto exit_unlock;
+
+	ret = regmap_read(rmi_dev->regmap, SBRMI_OUTBNDMSG7, &ec);
+	if (ret || (ec && ec != ERR_WITH_DATA))
+		goto exit_clear_alert;
+
+	/*
+	 * For a read operation, the initiator (BMC) reads the firmware
+	 * response Command Data Out[31:0] from SBRMI::OutBndMsg_inst[4:1]
+	 * {SBRMI_x34(MSB):SBRMI_x31(LSB)}.
+	 */
+	if (msg->data_in.reg_in[RD_FLAG_INDEX]) {
+		for (i = 0; i < MB_DATA_SIZE; i++) {
+			ret = regmap_read(rmi_dev->regmap,
+					  SBRMI_OUTBNDMSG1 + i, &bytes);
+			if (ret < 0)
+				break;
+			msg->data_out.reg_out[i] = bytes;
+		}
+	}
+exit_clear_alert:
+	/*
+	 * BMC must write 1'b1 to SBRMI::Status[SwAlertSts] to clear the
+	 * ALERT to initiator
+	 */
+	ret = regmap_write(rmi_dev->regmap, SBRMI_STATUS,
+			   SW_ALERT_MASK);
+	if (ec) {
+		ret = -EPROTOTYPE;
+		msg->fw_ret_code = ec;
+	}
+exit_unlock:
+	return ret;
+}

--- a/drivers/misc/amd-apml/sbrmi-common.h
+++ b/drivers/misc/amd-apml/sbrmi-common.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (C) 2021-2022 Advanced Micro Devices, Inc.
+ */
+
+#ifndef _AMD_APML_SBRMI_H_
+#define _AMD_APML_SBRMI_H_
+
+#include <linux/miscdevice.h>
+#include <linux/amd-apml.h>
+
+/* Each client has this additional data */
+/* in_progress: set during any transaction, mailbox/cpuid/mcamsr/readreg,
+ * to indicate a transaction is in progress.
+ * no_new_trans: set in rmmod/unbind path to indicate,
+ * not to accept new transactions
+ */
+struct apml_sbrmi_device {
+	struct miscdevice sbrmi_misc_dev;
+	struct completion misc_fops_done;
+	struct i3c_device *i3cdev;
+	struct i2c_client *client;
+	struct regmap *regmap;
+	struct mutex lock;
+	u32 pwr_limit_max;
+	atomic_t in_progress;
+	atomic_t no_new_trans;
+	u8 rev;
+	u8 dev_static_addr;
+} __packed;
+
+int rmi_mca_msr_read(struct apml_sbrmi_device *rmi_dev,
+		     struct apml_message *msg);
+int rmi_cpuid_read(struct apml_sbrmi_device *rmi_dev,
+		   struct apml_message *msg);
+int rmi_mailbox_xfer(struct apml_sbrmi_device *rmi_dev,
+		     struct apml_message *msg);
+int sbrmi_match_i3c(struct device *dev, const void *data);
+int sbrmi_match_i2c(struct device *dev, const void *data);
+#endif /*_AMD_APML_SBRMI_H_*/

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -1,0 +1,717 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ * sbrmi.c - hwmon driver for a SB-RMI mailbox
+ *           compliant AMD SoC device.
+ *
+ * Copyright (C) 2021-2022 Advanced Micro Devices, Inc.
+ */
+
+#include <linux/delay.h>
+#include <linux/err.h>
+#include <linux/hwmon.h>
+#include <linux/i3c/device.h>
+#include <linux/i3c/master.h>
+#include <linux/init.h>
+#include <linux/io.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/of.h>
+#include <linux/fs.h>
+#include <linux/regmap.h>
+#include <linux/version.h>
+
+#include "sbrmi-common.h"
+
+/* Do not allow setting negative power limit */
+#define SBRMI_PWR_MIN	0
+
+/* Try 2 byte address size before switching to 1 byte */
+#define MAX_RETRY	5
+
+
+/* SBRMI REVISION REG */
+#define SBRMI_REV	0x0
+
+#define MAX_WAIT_TIME_SEC	(3)
+
+/* SBRMI registers data out is 1 byte */
+#define SBRMI_REG_DATA_SIZE		0x1
+/* Default SBRMI register address is 1 byte */
+#define SBRMI_REG_ADDR_SIZE_DEF		0x1
+/* TURIN SBRMI register address is 2 byte */
+#define SBRMI_REG_ADDR_SIZE_TWO_BYTE	0x2
+
+/* Two xfers, one write and one read require to read the data */
+#define I3C_I2C_MSG_XFER_SIZE		0x2
+
+static int configure_regmap(struct apml_sbrmi_device *rmi_dev);
+
+enum sbrmi_msg_id {
+	SBRMI_READ_PKG_PWR_CONSUMPTION = 0x1,
+	SBRMI_WRITE_PKG_PWR_LIMIT,
+	SBRMI_READ_PKG_PWR_LIMIT,
+	SBRMI_READ_PKG_MAX_PWR_LIMIT,
+};
+
+static int sbrmi_get_max_pwr_limit(struct apml_sbrmi_device *rmi_dev)
+{
+	struct apml_message msg = { 0 };
+	int ret = 0;
+
+	msg.cmd = SBRMI_READ_PKG_MAX_PWR_LIMIT;
+	msg.data_in.reg_in[RD_FLAG_INDEX] = 1;
+	ret = rmi_mailbox_xfer(rmi_dev, &msg);
+	if (ret < 0)
+		return ret;
+	rmi_dev->pwr_limit_max = msg.data_out.mb_out[RD_WR_DATA_INDEX];
+
+	return ret;
+}
+
+static int sbrmi_read(struct device *dev, enum hwmon_sensor_types type,
+		      u32 attr, int channel, long *val)
+{
+	struct apml_sbrmi_device *rmi_dev = dev_get_drvdata(dev);
+	struct apml_message msg = { 0 };
+	int ret = 0;
+
+	if (type != hwmon_power)
+		return -EINVAL;
+	/* Configure regmap if not configured yet */
+	if (!rmi_dev->regmap) {
+		ret = configure_regmap(rmi_dev);
+		if (ret < 0) {
+			pr_err("regmap configuration failed with return value:%d in hwmon read ops\n", ret);
+			return ret;
+		}
+	}
+
+	mutex_lock(&rmi_dev->lock);
+	msg.data_in.reg_in[RD_FLAG_INDEX] = 1;
+
+	switch (attr) {
+	case hwmon_power_input:
+		msg.cmd = SBRMI_READ_PKG_PWR_CONSUMPTION;
+		ret = rmi_mailbox_xfer(rmi_dev, &msg);
+		break;
+	case hwmon_power_cap:
+		msg.cmd = SBRMI_READ_PKG_PWR_LIMIT;
+		ret = rmi_mailbox_xfer(rmi_dev, &msg);
+		break;
+	case hwmon_power_cap_max:
+		if (!rmi_dev->pwr_limit_max) {
+			/* Cache maximum power limit */
+			ret = sbrmi_get_max_pwr_limit(rmi_dev);
+		}
+		msg.data_out.mb_out[RD_WR_DATA_INDEX] = rmi_dev->pwr_limit_max;
+		break;
+	default:
+		ret = -EINVAL;
+	}
+	if (!ret)
+		/* hwmon power attributes are in microWatt */
+		*val = (long)msg.data_out.mb_out[RD_WR_DATA_INDEX] * 1000;
+
+	mutex_unlock(&rmi_dev->lock);
+	return ret;
+}
+
+static int sbrmi_write(struct device *dev, enum hwmon_sensor_types type,
+		       u32 attr, int channel, long val)
+{
+	struct apml_sbrmi_device *rmi_dev = dev_get_drvdata(dev);
+	struct apml_message msg = { 0 };
+	int ret;
+
+	if (type != hwmon_power && attr != hwmon_power_cap)
+		return -EINVAL;
+	/* Configure regmap if not configured yet */
+	if (!rmi_dev->regmap) {
+		ret = configure_regmap(rmi_dev);
+		if (ret < 0) {
+			pr_err("regmap configuration failed with return value:%d in hwmon write ops\n", ret);
+			return ret;
+		}
+	}
+	/*
+	 * hwmon power attributes are in microWatt
+	 * mailbox read/write is in mWatt
+	 */
+	val /= 1000;
+
+	val = clamp_val(val, SBRMI_PWR_MIN, rmi_dev->pwr_limit_max);
+
+	msg.cmd = SBRMI_WRITE_PKG_PWR_LIMIT;
+	msg.data_in.mb_in[RD_WR_DATA_INDEX] = val;
+	msg.data_in.reg_in[RD_FLAG_INDEX] = 0;
+
+	mutex_lock(&rmi_dev->lock);
+	ret = rmi_mailbox_xfer(rmi_dev, &msg);
+	mutex_unlock(&rmi_dev->lock);
+	return ret;
+}
+
+static umode_t sbrmi_is_visible(const void *data,
+				enum hwmon_sensor_types type,
+				u32 attr, int channel)
+{
+	switch (type) {
+	case hwmon_power:
+		switch (attr) {
+		case hwmon_power_input:
+		case hwmon_power_cap_max:
+			return 0444;
+		case hwmon_power_cap:
+			return 0644;
+		}
+		break;
+	default:
+		break;
+	}
+	return 0;
+}
+
+static const struct hwmon_channel_info *sbrmi_info[] = {
+	HWMON_CHANNEL_INFO(power,
+			   HWMON_P_INPUT | HWMON_P_CAP | HWMON_P_CAP_MAX),
+	NULL
+};
+
+static const struct hwmon_ops sbrmi_hwmon_ops = {
+	.is_visible = sbrmi_is_visible,
+	.read = sbrmi_read,
+	.write = sbrmi_write,
+};
+
+static const struct hwmon_chip_info sbrmi_chip_info = {
+	.ops = &sbrmi_hwmon_ops,
+	.info = sbrmi_info,
+};
+
+static long sbrmi_ioctl(struct file *fp, unsigned int cmd, unsigned long arg)
+{
+	int __user *arguser = (int  __user *)arg;
+	struct apml_message msg = { 0 };
+	bool read = false;
+	int ret = -EFAULT;
+	struct apml_sbrmi_device *rmi_dev;
+
+	rmi_dev = fp->private_data;
+	if (!rmi_dev)
+		return -ENODEV;
+
+	/*
+	 * If device remove/unbind is called do not allow new transaction
+	 */
+	if (atomic_read(&rmi_dev->no_new_trans))
+		return -EBUSY;
+	/* Copy the structure from user */
+	if (copy_struct_from_user(&msg, sizeof(msg), arguser,
+				  sizeof(struct apml_message)))
+		return ret;
+	/*
+	 * Only one I2C/I3C transaction can happen at
+	 * one time. Take lock across so no two protocol is
+	 * invoked at same time, modifying the register value.
+	 */
+	mutex_lock(&rmi_dev->lock);
+	/* Verify device unbind/remove is not invoked */
+	if (atomic_read(&rmi_dev->no_new_trans)) {
+		mutex_unlock(&rmi_dev->lock);
+		return -EBUSY;
+	}
+
+	/* Is this a read/monitor/get request */
+	if (msg.data_in.reg_in[RD_FLAG_INDEX])
+		read = true;
+
+	/*
+	 * Set the in_progress variable to true, to wait for
+	 * completion during unbind/remove of driver
+	 */
+	atomic_set(&rmi_dev->in_progress, 1);
+
+	switch (msg.cmd) {
+	case 0 ... 0x999:
+		/* Mailbox protocol */
+		ret = rmi_mailbox_xfer(rmi_dev, &msg);
+		break;
+	case APML_CPUID:
+		ret = rmi_cpuid_read(rmi_dev, &msg);
+		break;
+	case APML_MCA_MSR:
+		/* MCAMSR protocol */
+		ret = rmi_mca_msr_read(rmi_dev, &msg);
+		break;
+	case APML_REG:
+		/* REG R/W */
+		if (read) {
+			ret = regmap_read(rmi_dev->regmap,
+					  msg.data_in.mb_in[REG_OFF_INDEX],
+					  &msg.data_out.mb_out[RD_WR_DATA_INDEX]);
+		} else {
+			ret = regmap_write(rmi_dev->regmap,
+					    msg.data_in.mb_in[REG_OFF_INDEX],
+					    msg.data_in.reg_in[REG_VAL_INDEX]);
+		}
+		break;
+	default:
+		break;
+	}
+
+	/* Send complete only if device is unbinded/remove */
+	if (atomic_read(&rmi_dev->no_new_trans))
+		complete(&rmi_dev->misc_fops_done);
+
+	atomic_set(&rmi_dev->in_progress, 0);
+	mutex_unlock(&rmi_dev->lock);
+
+	/* Copy results back to user only for get/monitor commands and firmware failures */
+	if ((read && !ret) || ret == -EPROTOTYPE) {
+		if (copy_to_user(arguser, &msg, sizeof(struct apml_message)))
+			ret = -EFAULT;
+	}
+	return ret;
+}
+
+static int sbrmi_open(struct inode *inode, struct file *filp)
+{
+	struct miscdevice *mdev = filp->private_data;
+	struct apml_sbrmi_device *rmi_dev = container_of(mdev, struct apml_sbrmi_device,
+							 sbrmi_misc_dev);
+	int ret = 0;
+
+	if (!rmi_dev)
+		return -ENODEV;
+
+	if (!rmi_dev->regmap) {
+		ret = configure_regmap(rmi_dev);
+		if (ret < 0) {
+			pr_err("regmap configuration failed with return value:%d in misc dev open\n", ret);
+			return ret;
+		}
+	}
+	filp->private_data = rmi_dev;
+	return 0;
+}
+
+static int sbrmi_release(struct inode *inode, struct file *filp)
+{
+	filp->private_data = NULL;
+
+	return 0;
+}
+
+static const struct file_operations sbrmi_fops = {
+	.owner		= THIS_MODULE,
+	.open		= sbrmi_open,
+	.release	= sbrmi_release,
+	.unlocked_ioctl	= sbrmi_ioctl,
+	.compat_ioctl	= sbrmi_ioctl,
+};
+
+static int create_misc_rmi_device(struct apml_sbrmi_device *rmi_dev,
+				  struct device *dev)
+{
+	int ret;
+
+	rmi_dev->sbrmi_misc_dev.name		= devm_kasprintf(dev, GFP_KERNEL,
+						  "sbrmi-%x", rmi_dev->dev_static_addr);
+	rmi_dev->sbrmi_misc_dev.minor		= MISC_DYNAMIC_MINOR;
+	rmi_dev->sbrmi_misc_dev.fops		= &sbrmi_fops;
+	rmi_dev->sbrmi_misc_dev.parent		= dev;
+	rmi_dev->sbrmi_misc_dev.nodename	= devm_kasprintf(dev, GFP_KERNEL,
+						  "sbrmi-%x", rmi_dev->dev_static_addr);
+	rmi_dev->sbrmi_misc_dev.mode		= 0600;
+
+	ret = misc_register(&rmi_dev->sbrmi_misc_dev);
+	if (ret)
+		return ret;
+
+	dev_info(dev, "register %s device\n", rmi_dev->sbrmi_misc_dev.name);
+	return ret;
+}
+
+static int sbrmi_i2c_reg_read(struct i2c_client *i2cdev, int reg_size, u32 *val)
+{
+	struct i2c_msg xfer[I3C_I2C_MSG_XFER_SIZE];
+	int reg = SBRMI_REV;
+	int val_size = SBRMI_REG_DATA_SIZE;
+
+	xfer[0].addr = i2cdev->addr;
+	xfer[0].flags = 0;
+	xfer[0].len = reg_size;
+	xfer[0].buf = (void *)&reg;
+
+	xfer[1].addr = i2cdev->addr;
+	xfer[1].flags = I2C_M_RD;
+	xfer[1].len = val_size;
+	xfer[1].buf = (void *)val;
+
+	return i2c_transfer(i2cdev->adapter, xfer, I3C_I2C_MSG_XFER_SIZE);
+}
+
+static int sbrmi_i2c_identify_reg_addr_size(struct i2c_client *i2c, u32 *size, u32 *rev)
+{
+	u32 reg_size;
+	int ret, i;
+
+	reg_size = SBRMI_REG_ADDR_SIZE_TWO_BYTE;
+
+	/*
+	 * Sending 1 byte address size in Turin cause unrecoverable error
+	 * Before trying to switch to 1 bytes, retry. 
+	 */
+	for (i = 0; i < MAX_RETRY; i++) {
+		ret = sbrmi_i2c_reg_read(i2c, reg_size, rev);
+		if (ret != I3C_I2C_MSG_XFER_SIZE) {
+			usleep_range(10000, 20000);
+			continue;
+		} else {
+			break;
+		}
+	}
+	if (ret != I3C_I2C_MSG_XFER_SIZE) {
+		reg_size = SBRMI_REG_ADDR_SIZE_DEF;
+		ret = sbrmi_i2c_reg_read(i2c, reg_size, rev);
+		if (ret != I3C_I2C_MSG_XFER_SIZE) {
+			pr_err("I2C reg read failed with return value:%d\n", ret);
+			return ret;
+		}
+	}
+
+	if (*rev == 0x21)
+		*size = SBRMI_REG_ADDR_SIZE_TWO_BYTE;
+	else
+		*size = SBRMI_REG_ADDR_SIZE_DEF;
+	return ret;
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 3, 0)
+static int sbrmi_i2c_probe(struct i2c_client *client,
+			   const struct i2c_device_id *rmi_id)
+#else
+static int sbrmi_i2c_probe(struct i2c_client *client)
+#endif
+{
+	struct device *dev = &client->dev;
+	struct device *hwmon_dev;
+	struct apml_sbrmi_device *rmi_dev;
+
+	rmi_dev = devm_kzalloc(dev, sizeof(struct apml_sbrmi_device), GFP_KERNEL);
+	if (!rmi_dev)
+		return -ENOMEM;
+
+	atomic_set(&rmi_dev->in_progress, 0);
+	atomic_set(&rmi_dev->no_new_trans, 0);
+	rmi_dev->client = client;
+	mutex_init(&rmi_dev->lock);
+
+	dev_set_drvdata(dev, (void *)rmi_dev);
+
+	hwmon_dev = devm_hwmon_device_register_with_info(dev, client->name,
+							 rmi_dev,
+							 &sbrmi_chip_info,
+							 NULL);
+
+	if (!hwmon_dev)
+		return PTR_ERR_OR_ZERO(hwmon_dev);
+
+	rmi_dev->dev_static_addr = client->addr;
+
+	init_completion(&rmi_dev->misc_fops_done);
+	return create_misc_rmi_device(rmi_dev, dev);
+}
+
+static int sbrmi_i3c_reg_read(struct i3c_device *i3cdev, int reg_size, u32 *val)
+{
+	struct i3c_priv_xfer xfers[I3C_I2C_MSG_XFER_SIZE];
+	int reg = SBRMI_REV;
+	int val_size = SBRMI_REG_DATA_SIZE;
+
+	xfers[0].rnw = false;
+	xfers[0].len = reg_size;
+	xfers[0].data.out = &reg;
+
+	xfers[1].rnw = true;
+	xfers[1].len = val_size;
+	xfers[1].data.in = val;
+
+	return i3c_device_do_priv_xfers(i3cdev, xfers, I3C_I2C_MSG_XFER_SIZE);
+}
+
+static int sbrmi_i3c_identify_reg_addr_size(struct i3c_device *i3cdev, u32 *size, u32 *rev)
+{
+	u32 reg_size;
+	int ret, i;
+
+	reg_size = SBRMI_REG_ADDR_SIZE_TWO_BYTE;
+	for (i = 0; i < MAX_RETRY; i++) {
+		ret = sbrmi_i3c_reg_read(i3cdev, reg_size, rev);
+		if (ret < 0) {
+			usleep_range(10000, 20000);
+			continue;
+		} else {
+			break;
+		}
+	}
+	if (ret < 0) {
+		reg_size = SBRMI_REG_ADDR_SIZE_DEF;
+		ret = sbrmi_i3c_reg_read(i3cdev, reg_size, rev);
+		if (ret < 0) {
+			pr_err("I3C reg read failed with return value:%d\n", ret);
+			return ret;
+		}
+	}
+
+	if (*rev == 0x21)
+		*size = SBRMI_REG_ADDR_SIZE_TWO_BYTE;
+	else
+		*size = SBRMI_REG_ADDR_SIZE_DEF;
+	return ret;
+}
+
+static int init_rmi_regmap(struct apml_sbrmi_device *rmi_dev, u32 size, u32 rev)
+{
+	struct regmap_config sbrmi_regmap_config = {
+		.reg_bits = 8 * size,
+		.val_bits = 8,
+		.reg_format_endian = REGMAP_ENDIAN_LITTLE,
+	};
+	struct regmap *regmap;
+
+	if (rmi_dev->i3cdev) {
+		regmap = devm_regmap_init_i3c(rmi_dev->i3cdev,
+					      &sbrmi_regmap_config);
+		if (IS_ERR(regmap)) {
+			dev_err(&rmi_dev->i3cdev->dev,
+				"Failed to register i3c regmap %d\n",
+				(int)PTR_ERR(regmap));
+			return PTR_ERR(regmap);
+		}
+	} else if (rmi_dev->client) {
+		regmap = devm_regmap_init_i2c(rmi_dev->client,
+					      &sbrmi_regmap_config);
+		if (IS_ERR(regmap))
+			return PTR_ERR(regmap);
+	} else {
+		return -ENODEV;
+	}
+
+	rmi_dev->regmap = regmap;
+	rmi_dev->rev = rev;
+	return 0;
+}
+
+/*
+ * configure_regmap call should happen in probe, however if the server is power off,
+ * regmap configuration may fail and hence driver probe will fail.
+ * configure the regmap in hwmon/ioctl
+ */
+static int configure_regmap(struct apml_sbrmi_device *rmi_dev)
+{
+	u32 size;
+	u32 rev = 0;
+	int ret = 0;
+
+	if (rmi_dev->i3cdev) {
+		ret = sbrmi_i3c_identify_reg_addr_size(rmi_dev->i3cdev, &size, &rev);
+		if (ret < 0) {
+			pr_err("Reg size identification failed with return value:%d\n", ret);
+			return ret;
+		}
+	} else if (rmi_dev->client) {
+		ret = sbrmi_i2c_identify_reg_addr_size(rmi_dev->client, &size, &rev);
+		if (ret < 0) {
+			pr_err("Reg size identification failed with return value:%d\n", ret);
+			return ret;
+		}
+	} else {
+		return ret;
+	}
+	ret = init_rmi_regmap(rmi_dev, size, rev);
+	return ret;
+}
+
+static int sbrmi_i3c_probe(struct i3c_device *i3cdev)
+{
+	struct device *dev = &i3cdev->dev;
+	struct device *hwmon_dev;
+	struct apml_sbrmi_device *rmi_dev;
+
+	dev_info(dev, "SBRMI: PID: %llx\n", i3cdev->desc->info.pid);
+	if (!(i3cdev->desc->info.pid == 0x1000 || i3cdev->desc->info.pid == 0x22400000002))
+		return -ENXIO;
+
+	rmi_dev = devm_kzalloc(dev, sizeof(struct apml_sbrmi_device), GFP_KERNEL);
+	if (!rmi_dev)
+		return -ENOMEM;
+
+	atomic_set(&rmi_dev->in_progress, 0);
+	atomic_set(&rmi_dev->no_new_trans, 0);
+	rmi_dev->i3cdev = i3cdev;
+	mutex_init(&rmi_dev->lock);
+
+	dev_set_drvdata(dev, (void *)rmi_dev);
+
+	hwmon_dev = devm_hwmon_device_register_with_info(dev, "sbrmi_i3c", rmi_dev,
+							 &sbrmi_chip_info, NULL);
+
+	if (!hwmon_dev)
+		return PTR_ERR_OR_ZERO(hwmon_dev);
+
+	/* Need to verify for the static address for i3cdev */
+	rmi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
+
+	init_completion(&rmi_dev->misc_fops_done);
+	return create_misc_rmi_device(rmi_dev, dev);
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+static int sbrmi_i2c_remove(struct i2c_client *client)
+#else
+static void sbrmi_i2c_remove(struct i2c_client *client)
+#endif
+{
+	struct apml_sbrmi_device *rmi_dev = dev_get_drvdata(&client->dev);
+
+	if (!rmi_dev)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+		return 0;
+#else
+		return;
+#endif
+
+	/*
+	 * Set the no_new_trans so no new transaction can
+	 * occur in sbrmi_ioctl
+	 */
+	atomic_set(&rmi_dev->no_new_trans, 1);
+	/*
+	 * If any transaction is in progress wait for the
+	 * transaction to get complete
+	 * Max wait for 3 sec for any pending transaction to
+	 * complete
+	 */
+	if (atomic_read(&rmi_dev->in_progress))
+		wait_for_completion_timeout(&rmi_dev->misc_fops_done,
+					    MAX_WAIT_TIME_SEC * HZ);
+	misc_deregister(&rmi_dev->sbrmi_misc_dev);
+	/* Assign fops and parent of misc dev to NULL */
+	rmi_dev->sbrmi_misc_dev.fops = NULL;
+	rmi_dev->sbrmi_misc_dev.parent = NULL;
+
+	dev_info(&client->dev, "Removed sbrmi driver\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 1, 0)
+	return 0;
+#endif
+}
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+static int sbrmi_i3c_remove(struct i3c_device *i3cdev)
+#else
+static void sbrmi_i3c_remove(struct i3c_device *i3cdev)
+#endif
+{
+	struct apml_sbrmi_device *rmi_dev = dev_get_drvdata(&i3cdev->dev);
+
+	if (!rmi_dev)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+		return 0;
+#else
+		return;
+#endif
+
+	/*
+	 * Set the no_new_trans so no new transaction can
+	 * occur in sbrmi_ioctl
+	 */
+	atomic_set(&rmi_dev->no_new_trans, 1);
+	/*
+	 * If any transaction is in progress wait for the
+	 * transaction to get complete
+	 * Max wait for 3 sec for any pending transaction to
+	 * complete
+	 */
+	if (atomic_read(&rmi_dev->in_progress))
+		wait_for_completion_timeout(&rmi_dev->misc_fops_done,
+					    MAX_WAIT_TIME_SEC * HZ);
+	misc_deregister(&rmi_dev->sbrmi_misc_dev);
+	/* Assign fops and parent of misc dev to NULL */
+	rmi_dev->sbrmi_misc_dev.fops = NULL;
+	rmi_dev->sbrmi_misc_dev.parent = NULL;
+
+	dev_info(&i3cdev->dev, "Removed sbrmi_i3c driver\n");
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+	return 0;
+#endif
+}
+
+static const struct i2c_device_id sbrmi_id[] = {
+	{"sbrmi", 0},
+	{}
+};
+MODULE_DEVICE_TABLE(i2c, sbrmi_id);
+
+static const struct of_device_id __maybe_unused sbrmi_of_match[] = {
+	{
+		.compatible = "amd,sbrmi",
+	},
+	{ },
+};
+MODULE_DEVICE_TABLE(of, sbrmi_of_match);
+
+static const struct i3c_device_id sbrmi_i3c_id[] = {
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x2, NULL),
+	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
+	{}
+};
+MODULE_DEVICE_TABLE(i3c, sbrmi_i3c_id);
+
+static struct i2c_driver sbrmi_driver = {
+	.class = I2C_CLASS_HWMON,
+	.driver = {
+		.name = "sbrmi",
+		.of_match_table = of_match_ptr(sbrmi_of_match),
+	},
+	.probe = sbrmi_i2c_probe,
+	.remove = sbrmi_i2c_remove,
+	.id_table = sbrmi_id,
+};
+
+static struct i3c_driver sbrmi_i3c_driver = {
+	.driver = {
+		.name = "sbrmi_i3c",
+	},
+	.probe = sbrmi_i3c_probe,
+	.remove = sbrmi_i3c_remove,
+	.id_table = sbrmi_i3c_id,
+};
+
+module_i3c_i2c_driver(sbrmi_i3c_driver, &sbrmi_driver)
+
+int sbrmi_match_i3c(struct device *dev, const void *data)
+{
+	const struct device_node *node = (const struct device_node *)data;
+
+	if (dev->of_node == node && dev->driver == &sbrmi_i3c_driver.driver)
+		return 1;
+	return 0;
+}
+EXPORT_SYMBOL_GPL(sbrmi_match_i3c);
+
+int sbrmi_match_i2c(struct device *dev, const void *data)
+{
+	const struct device_node *node = (const struct device_node *)data;
+
+	if (dev->of_node == node && dev->driver == &sbrmi_driver.driver)
+		return 1;
+	return 0;
+}
+EXPORT_SYMBOL_GPL(sbrmi_match_i2c);
+
+MODULE_AUTHOR("Akshay Gupta <akshay.gupta@amd.com>");
+MODULE_AUTHOR("Naveenkrishna Chatradhi <naveenkrishna.chatradhi@amd.com>");
+MODULE_DESCRIPTION("Hwmon driver for AMD SB-RMI emulated sensor");
+MODULE_LICENSE("GPL");

--- a/include/uapi/linux/amd-apml.h
+++ b/include/uapi/linux/amd-apml.h
@@ -1,0 +1,80 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+/*
+ * Copyright (C) 2021-2022 Advanced Micro Devices, Inc.
+ */
+#ifndef _AMD_APML_H_
+#define _AMD_APML_H_
+
+#include <linux/types.h>
+
+/*
+ * Currently signal 33 to 64 are unused,
+ * using user signal number from that range
+ */
+#define USR_SIGNAL	44
+
+enum apml_protocol {
+	APML_CPUID	= 0x1000,
+	APML_MCA_MSR,
+	APML_REG,
+};
+
+/* These are byte indexes into data_in and data_out arrays */
+#define RD_WR_DATA_INDEX	0
+#define REG_OFF_INDEX		0
+#define REG_VAL_INDEX		4
+#define THREAD_LOW_INDEX	4
+#define THREAD_HI_INDEX		5
+#define EXT_FUNC_INDEX		6
+#define RD_FLAG_INDEX		7
+
+#define MB_DATA_SIZE		4
+
+struct apml_message {
+	/* message ids:
+	 * Mailbox Messages:	0x0 ... 0x999
+	 * APML_CPUID:		0x1000
+	 * APML_MCA_MSR:	0x1001
+	 * APML_REG:		0x1002 (RMI & TSI reg access)
+	 */
+	__u32 cmd;
+
+	/*
+	 * 8 bit data for reg read,
+	 * 32 bit data in case of mailbox,
+	 * upto 64 bit in case of cpuid and mca msr
+	 */
+	union {
+		__u64 cpu_msr_out;
+		__u32 mb_out[2];
+		__u8 reg_out[8];
+	} data_out;
+
+	/*
+	 * [0]...[3] mailbox 32bit input
+	 *	     cpuid & mca msr,
+	 *	     rmi rd/wr: reg_offset
+	 * [4][5] cpuid & mca msr: thread
+	 * [4] rmi reg wr: value
+	 * [6] cpuid: ext function & read eax/ebx or ecx/edx
+	 *	[7:0] -> bits [7:4] -> ext function &
+	 *	bit [0] read eax/ebx or ecx/edx
+	 * [7] read/write functionality
+	 */
+	union {
+		__u64 cpu_msr_in;
+		__u32 mb_in[2];
+		__u8 reg_in[8];
+	} data_in;
+	/*
+	 * Status code is returned in case of CPUID/MCA access
+	 * Error code is returned in case of soft mailbox
+	 */
+	__u32 fw_ret_code;
+} __attribute__((packed));
+
+/* ioctl command for mailbox msgs using generic _IOWR */
+#define SBRMI_BASE_IOCTL_NR      0xF9
+#define SBRMI_IOCTL_CMD          _IOWR(SBRMI_BASE_IOCTL_NR, 0, struct apml_message)
+
+#endif /*_AMD_APML_H_*/


### PR DESCRIPTION
Updated Kconfig and Makefile to include SBTSI and SBRMI driver.

The apml_sbtsi and apml_sbrmi driver is ported from the apml_modules github repo
(https://github.com/amd/apml_modules/) to linux-aspeed repository.
