### PR TITLE
Linux aspeed new Senegal board support

### DIFF
--- a/arch/arm64/boot/dts/aspeed/Makefile
+++ b/arch/arm64/boot/dts/aspeed/Makefile
@@ -5,3 +5,4 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
 	aspeed-bmc-amd-marley.dtb \
 	aspeed-bmc-amd-morocco.dtb \
 	aspeed-bmc-amd-nigeria.dtb \
+	aspeed-bmc-amd-senegal.dtb \

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-senegal.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-senegal.dts
@@ -1,0 +1,767 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2024 AMD Inc.
+// Author: Mahesh Kurapati <mahesh.kurapati@amd.com>
+
+/dts-v1/;
+
+#include "aspeed-g7.dtsi"
+#include "dt-bindings/gpio/aspeed-gpio.h"
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/i3c/i3c.h>
+
+/ {
+	model = "AMD Senegal VRB";
+	compatible = "amd,senegal-bmc", "aspeed,ast2700";
+	
+	chosen {
+		stdout-path = &uart12;
+		bootargs = "console=ttyS12,115200n8";
+	};
+
+	firmware {
+		optee: optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+
+	memory@400000000 {
+		device_type = "memory";
+		reg = <0x4 0x00000000 0x0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		mcu_fw: mcu-firmware@42fe00000 {
+			reg = <0x4 0x2fe00000 0x0 0x200000>;
+			no-map;
+		};
+
+		atf: trusted-firmware-a@430000000 {
+			reg = <0x4 0x30000000 0x0 0x80000>;
+			no-map;
+		};
+
+		optee_core: optee_core@430080000 {
+			reg = <0x4 0x30080000 0x0 0x1000000>;
+			no-map;
+		};
+
+		video_engine_memory0: video0 {
+			size = <0x0 0x04000000>;
+			alignment = <0x0 0x00010000>;
+			compatible = "shared-dma-pool";
+			reusable;
+		};
+
+		pcc_memory: pccbuffer {
+                        reg = <0xE0000000 0x00001000>; /* 4K */
+			no-map;
+                };
+	};
+
+	aliases {
+		i2c100 = &P0_conn_012_cpu;
+		i2c101 = &P0_conn_345_cpu;
+		i2c102 = &P0_conn_012_mgmt;
+		i2c103 = &P0_conn_345_mgmt;
+		i2c104 = &fan_pdb;
+		i2c105 = &P0_pcp;
+		i2c106 = &NC_5;
+		i2c107 = &NC_6;
+		i2c116 = &P0_id;
+		i2c117 = &P0_clk;
+		i2c118 = &P0_vr;
+		i2c119 = &NC_1;
+		i2c120 = &brd_vr;
+		i2c121 = &temp;
+		i2c122 = &fan_0;
+		i2c123 = &fan_1;
+		i2c124 = &therm;
+		i2c125 = &NC_2;
+		i2c126 = &adc_fpga;
+		i2c127 = &lom;
+		i2c128 = &adc_pdb;
+		i2c129 = &adc_prb;
+		i2c130 = &NC_3;
+		i2c131 = &NC_4;
+		i2c200 = &picpwr_fan_0;
+		i2c201 = &picpwr_fan_1;
+		i2c202 = &picpwr_pdb;
+		i2c203 = &churro_fans_0_0;
+		i2c204 = &churro_fans_0_1;
+		i2c205 = &churro_id;
+		i2c206 = &churro_mcu;
+		i2c207 = &NC_7;
+	};
+};
+
+&mdio0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	ethphy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+};
+
+&pinctrl1 {
+	pinctrl_rgmii0_driving: rgmii0_driving {
+		pins = "C20", "C19", "A8", "R14", "A7", "P14",
+		       "D20", "A6", "B6", "N14", "B7", "B8";
+		drive-strength = <1>;
+	};
+};
+
+&mac0 {
+	status = "okay";
+	phy-mode = "rgmii";
+	phy-handle = <&ethphy0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rgmii0_default &pinctrl_rgmii0_driving>;
+};
+
+&mac1 {
+        status = "okay";
+        pinctrl-names = "default";
+        pinctrl-0 = <&pinctrl_rmii1_default>;
+        clock-names = "MACCLK", "RCLK";
+        use-ncsi;
+};
+
+&fmc {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_fwspi_quad_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "bmc";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+#include "amd-flash-layout-128.dtsi"
+	};
+
+	flash@1 {
+		status = "okay";
+		m25p,fast-read;
+		label = "mpflash";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi0_default &pinctrl_spi0_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <16000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_spi1_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <16000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+//BMC Console
+&uart12 {
+	status = "okay";
+};
+
+&i2c0 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+	status = "okay";
+};
+
+&i2c1 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+	status = "okay";
+};
+
+&i2c7 {
+	status = "okay";
+	clock-frequency = <400000>;
+	scmeeprom@50 {
+		compatible = "atmel,24c08";
+		reg = <0x50>;
+	};
+};
+
+&i2c8 {
+	// Net name SCM_I2C<0>
+	status = "okay";
+	clock-frequency = <400000>;
+	hpmeeprom@50 {
+		compatible = "microchip,24lc256","atmel,24c256";
+		reg = <0x50>;
+	};
+
+	i2cswitch@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		P0_conn_012_cpu: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		P0_conn_345_cpu: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+                P0_conn_012_mgmt: i2c@2 {
+                        reg = <2>;
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+                };
+
+                P0_conn_345_mgmt: i2c@3 {
+                        reg = <3>;
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+                };
+
+		fan_pdb: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			i2cswitch@71 {
+				compatible = "nxp,pca9546";
+				reg = <0x71>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				picpwr_fan_0: i2c@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					i2cswitch@76 {
+						compatible = "nxp,pca9546";
+						reg = <0x76>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						churro_fans_0_0: i2c@0 {
+							reg = <0>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							emc2305@4d {
+								compatible = "smsc,emc2305";
+								reg = <0x4d>;
+								#cooling-cells = <0x02>;
+
+								fan@0 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@1 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@2 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@3 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+							};
+						};
+
+						churro_fans_0_1: i2c@1 {
+							reg = <1>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							emc2305@4d {
+								compatible = "smsc,emc2305";
+								reg = <0x4d>;
+								#cooling-cells = <0x02>;
+
+								fan@0 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@1 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@2 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@3 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+							};
+						};
+
+						churro_id: i2c@2 {
+							reg = <2>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+						};
+
+						churro_mcu: i2c@3 {
+							reg = <3>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+						};
+					};
+				};
+
+				picpwr_fan_1: i2c@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+
+				picpwr_pdb: i2c@2 {
+					reg = <2>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+
+				NC_7: i2c@3 {
+					reg = <3>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+			};
+		};
+
+		P0_pcp: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		NC_5: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		NC_6: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+};
+
+&i2c10 {
+	// Net name i2c2 (SCM_I2C_SDA<2>) - FAN/LM75/ADC
+	status = "okay";
+	clock-frequency = <400000>;
+
+	i2cswitch@70 {
+		compatible = "nxp,pca9546";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		P0_id: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		P0_clk: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		P0_vr: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			core0run@40 {
+				//P0_VDD_CORE_0_RUN
+				compatible = "isil,isl68137";
+				reg = <0x40>;
+			};
+			core1run@41 {
+				//P0_VDD_CORE_1_RUN
+				compatible = "isil,isl68137";
+				reg = <0x41>;
+			};
+			vddvddiorun@42 {
+				//P0_VDD_VDDIO_RUN
+				compatible = "isil,isl68137";
+				reg = <0x42>;
+			};
+			vdd33s5run@46 {
+				//P0_VDD_33_S5_RUN
+				compatible = "pmbus";
+				reg = <0x46>;
+			};
+			vdd18s5run@47 {
+				//P0_VDD_18_S5_RUN
+				compatible = "pmbus";
+			};
+		};
+
+		NC_1: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	i2cswitch@71 {
+		compatible = "nxp,pca9548";
+		reg = <0x71>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		brd_vr: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			vdd33dual@43 {
+				//VDD_33_DUAL VRM
+				compatible = "pmbus";
+				reg = <0x43>;
+			};
+			vdd33run@45 {
+				//VDD_33_RUN VRM
+				compatible = "pmbus";
+				reg = <0x45>;
+			};
+			vdd5dual@48 {
+				//VDD_5_DUAL VRM
+				compatible = "pmbus";
+				reg = <0x48>;
+			};
+		};
+
+		temp: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		fan_0: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+		};
+
+		fan_1: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+                        };
+		};
+
+		therm: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		NC_2: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		adc_fpga: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		lom: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+	i2cswitch@72 {
+		compatible = "nxp,pca9546";
+		reg = <0x72>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		adc_pdb: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		adc_prb: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		NC_3: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		NC_4: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
+
+};
+
+&i3c4 {
+	status = "okay";
+	initial-role = "primary";
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
+	i2c-scl-hz = <1000000>;
+
+	sbtsi_p0_0: sbtsi@4c,22400000001 {
+		reg = <0x4c 0x224 0x00000001>;
+		assigned-address = <0x4c>;
+	};
+	sbrmi_p0_1: sbrmi@3c,22400000002 {
+		reg = <0x3c 0x224 0x00000002>;
+		assigned-address = <0x3c>;
+	};
+};
+
+#define JESD300_SPD_I3C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
+        reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
+        assigned-address = <0x ## addr>; \
+        dcr = /bits/ 8 <0xda>; \
+        bcr = /bits/ 8 <0x6>; \
+}
+
+&i3c8 {
+	status = "okay";
+	initial-role = "primary";
+	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
+	internal-pullup = <2>;
+	i3c-scl-hz = <10000000>;
+	i2c-scl-hz = <1000000>;
+
+	i3c_hub0: i3chub0@70,4CC00000000 {
+		reg = <0x70 0x4CC 0x00000000>;
+		assigned-address = <0x70>;
+	};
+
+	i3c_hub1: i3chub1@71,4CC00000001 {
+		reg = <0x71 0x4CC 0x00000001>;
+		assigned-address = <0x71>;
+	};
+
+	JESD300_SPD_I3C_MODE(0, 0, 50);
+	JESD300_SPD_I3C_MODE(0, 1, 51);
+	JESD300_SPD_I3C_MODE(0, 2, 52);
+	JESD300_SPD_I3C_MODE(0, 3, 53);
+	JESD300_SPD_I3C_MODE(0, 4, 54);
+	JESD300_SPD_I3C_MODE(0, 5, 55);
+	JESD300_SPD_I3C_MODE(0, 6, 56);
+	JESD300_SPD_I3C_MODE(0, 7, 57);
+};
+
+
+&gpio0 {
+        gpio-line-names =
+                /*A0-A7*/       "","","","","","","","",
+                /*B0-B7*/       "","","","","","","","",
+                /*C0-C7*/       "","","","","","","","",
+                /*D0-D7*/       "","","","","","","","",
+                /*E0-E7*/       "","","","","","","","",
+                /*F0-F7*/       "","","","","","","","",
+                /*G0-G7*/       "","","","","","","","",
+                /*H0-H7*/       "","","","","","","","",
+                /*I0-I7*/       "","","","","","","","",
+                /*J0-J7*/       "","","","","","","","",
+                /*K0-K7*/       "","","","","","","","",
+                /*L0-L7*/       "","","","","","","","",
+                /*M0-M7*/       "","","","","","","","",
+                /*N0-N7*/       "","","","","","","","",
+                /*O0-O7*/       "","","","","","","","",
+                /*P0-P7*/       "","","","","","","","",
+                /*Q0-Q7*/       "","","","","","","","",
+                /*R0-R7*/       "","","","","","","","",
+                /*S0-S7*/       "","","","","","","","",
+                /*T0-T7*/       "","","","","","","","",
+                /*U0-U7*/       "","","","","","","","",
+                /*V0-V7*/       "","","","","","","","",
+                /*W0-W7*/       "","","","","","","","",
+                /*X0-X7*/       "","","","","","","","",
+                /*Y0-Y7*/       "","","","","","","","",
+                /*Z0-Z7*/       "","","","","","","","",
+                /*AA0-AA7*/     "","","","","","","","",
+                /*AB0-AB7*/     "HPM_STBY_EN","P0_MGMT_ASSERT_CLR_CMOS",
+				"P0_MGMT_MON_PROCHOT_L","","","",
+				"P0_MGMT_ASSERT_NMI_BTN_L",
+				"MGMT_SYS_MON_ATX_PWR_OK",
+                /*AC0-AC7*/     "P0_PRESENT_L","P0_MGMT_MON_RSMRST_L",
+				"P0_MGMT_MON_POST_COMPLETE",
+				"P0_MGMT_MON_THERMTRIP_L",
+				"P0_MGMT_MON_PWR_GOOD","P0_ASSERT_RSMRST",
+				"P0_MGMT_SOC_RESET_L",
+				"P0_MGMT_MON_PSP_SOFT_FUSE_NTFY",
+                /*AD0-AD7*/     "P0_I3C_APML_ALERT_L","MGMT_HDT_SEL",
+				"SCM_JTAG_DBREQ","JTAG_TRST_N","P1_PRESENT_L",
+				"","","",
+                /*AE0-AE7*/     "P0_MGMT_ASSERT_RST_BTN_L",
+				"P0_MGMT_ASSERT_PWR_BTN_L",
+				"P0_MGMT_MON_RST_BTN_L",
+				"P0_MGMT_MON_PWR_BTN_L","","","","";
+};
+
+&video0 {
+	status = "okay";
+	memory-region = <&video_engine_memory0>;
+};
+
+&espi0 {
+	status = "okay";
+	perif-dma-mode;
+	oob-dma-mode;
+	flash-dma-mode;
+};
+
+&lpc0_pcc {
+        port-addr = <0x80>;
+        dma-mode;
+        A2600-15;
+        memory-region = <&pcc_memory>;
+        rec-mode = <0x1>;
+        port-addr-hbits-select = <0x1>;
+        port-addr-xbits = <0x3>;
+
+        status = "okay";
+};
+
+&ltpi0 {
+       status = "okay";
+};
+
+&uart9 {
+       /delete-property/ pinctrl-names;
+       /delete-property/ pinctrl-0;
+       status = "okay";
+};
+&vhuba1 {
+	status = "okay";
+};
+
+&usb3ahp {
+	status = "okay";
+};
+
+&phy2a {
+	status = "okay";
+};
+
+&phy3a {
+	status = "okay";
+};
+
+&lpc0_kcs2 {
+	status = "okay";
+	kcs-io-addr = <0xca2>;
+	kcs-channel = <2>;
+};
+
+&jtag1 {
+	status = "okay";
+};


### PR DESCRIPTION
Adding device tree for Senegal platform and the corresponding Makefile change.

Device tree enables the following:
    - eeproms, temp sensors, fans, gpios, and adc, etc.

Tested: verified on Senegal Rev-A board