### PR TITLE
ARM64:dts:aspeed: Change i3c bus speed

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -609,7 +609,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 
 	sbtsi_p0_0: sbtsi@4c,22400000001 {


### PR DESCRIPTION
Reduce the i3c bus speed from 12.5 Mhz to
10 Mhz as APML is not working at 12.5 Mhz.
This change is applicable only for Congo platform.

Tested fields: Verified APML in Congo system.