### PR TITLE
ARM64:dts:aspeed: Change i3c bus speed

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -419,7 +419,7 @@
         status = "okay";
         initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 
         sbtsi_p0_0: sbtsi@4c,22400000001 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -831,7 +831,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
@@ -848,7 +848,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 
 	sbtsi_p1_0: sbtsi@48,22400000001 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -495,7 +495,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
@@ -512,7 +512,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <12500000>;
+	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 
 	sbtsi_p1_0: sbtsi@48,22400000001 {


### PR DESCRIPTION
Platforms : Morocco, Kenya , Nigeria

Reduce the i3c bus speed from 12.5 Mhz to
10 Mhz as APML is not working at 12.5 Mhz.