### PR TITLE
ARM64:dts:aspeed Add Fan Cntl to kenya

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -88,6 +88,7 @@
 		i2c125 = &adc;
 		i2c126 = &rio;
 		i2c127 = &fio;
+		i2c203 = &fan_board;
 	};
 };
 
@@ -195,6 +196,26 @@
 	/delete-property/ pinctrl-names;
 	/delete-property/ pinctrl-0;
 	status = "okay";
+
+	i2cswitch@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		fan_board: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			nct7363@20 {
+				compatible = "nuvoton,nct7363";
+				reg = <0x20>;
+			};
+			nct7363@21 {
+				compatible = "nuvoton,nct7363";
+				reg = <0x21>;
+			};
+		};
+	};
 };
 
 &i2c7 {


### PR DESCRIPTION
Add NCT7363 fan controllers to Kenya Device Tree

tested: verified in Kenya platform