### PR TITLE
ARM64:dts:aspeed Add Fan Cntl to Nigeria

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -96,6 +96,7 @@
 		i2c133 = &p1_clk;
 		i2c134 = &p1_vr;
 		i2c135 = &p1_sec;
+		i2c203 = &fan_board;
 	};
 };
 
@@ -199,6 +200,26 @@
 	/delete-property/ pinctrl-names;
 	/delete-property/ pinctrl-0;
 	status = "okay";
+
+	i2cswitch@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		fan_board: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			nct7363@20 {
+				compatible = "nuvoton,nct7363";
+				reg = <0x20>;
+			};
+			nct7363@21 {
+				compatible = "nuvoton,nct7363";
+				reg = <0x21>;
+			};
+		};
+	};
 };
 
 &i2c7 {


### PR DESCRIPTION
Add NCT7363 fan controllers to Nigeria Device Tree

tested: verified in Nigeria platform