### PR TITLE
ARM64:dts:aspeed A1 DTS changes for BU

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -9,6 +9,8 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/i3c/i3c.h>
 
+//#define VERONA 1
+
 / {
 	model = "AMD Congo VRB";
 	compatible = "amd,congo-bmc", "aspeed,ast2700";
@@ -646,7 +648,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
-
+#ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
 		reg = <0x4c 0x224 0x00000001>;
 		assigned-address = <0x4c>;
@@ -655,7 +657,27 @@
 		reg = <0x3c 0x224 0x00000002>;
 		assigned-address = <0x3c>;
 	};
+#else
+	mctp-controller;
+
+	sbtsi_p0_0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_1: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
+	scoob_p0: scoob@5c,22400002118 {
+		reg = <0x5c 0x224 0x00002118>;
+		assigned-address = <0x5c>;
+	};
+#endif
 };
+
+#ifdef I3C_HUB
 
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
@@ -692,6 +714,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	JESD300_SPD_I3C_MODE(0, 6, 56);
 	JESD300_SPD_I3C_MODE(0, 7, 57);
 };
+#endif
 
 &gpio0 {
 	status = "okay";
@@ -722,7 +745,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*24-31*/ "","","","","","","","P0_MGMT_ASSERT_NMI_BTN_L",
 		/*32-39*/ "","P0_MGMT_SOC_RESET_L","",
 			"MGMT_HDT_SEL","","SCM_JTAG_DBREQ","","JTAG_TRST_N",
-		/*40-47*/ "","","","","","","","",
+		/*40-47*/ "","P0_MGMT_ASSERT_WARM_RST_BTN_L","","","","","","",
 		/*48-55*/ "","","","","","","","",
 		/*56-63*/ "","","","","","","","",
 		/*64-71*/ "","","","","","","","",

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -10,6 +10,8 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/i3c/i3c.h>
 
+//#define VERONA 1
+
 / {
 	model = "AMD Kenya PRB";
 	compatible = "amd,kenya-bmc", "aspeed,ast2700";
@@ -482,7 +484,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
-
+#ifdef VERONA
         sbtsi_p0_0: sbtsi@4c,22400000001 {
                 reg = <0x4c 0x224 0x00000001>;
                 assigned-address = <0x4c>;
@@ -491,7 +493,27 @@
                 reg = <0x3c 0x224 0x00000002>;
                 assigned-address = <0x3c>;
         };
+#else
+	mctp-controller;
+
+	sbtsi_p0_0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_1: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
+	scoob_p0: scoob@5c,22400002118 {
+		reg = <0x5c 0x224 0x00002118>;
+		assigned-address = <0x5c>;
+	};
+#endif
 };
+
+#ifdef I3C_HUB
 
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
@@ -528,6 +550,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         JESD300_SPD_I3C_MODE(0, 6, 56);
         JESD300_SPD_I3C_MODE(0, 7, 57);
 };
+#endif
 
 &gpio0 {
 	status = "okay";
@@ -558,7 +581,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*24-31*/ "","","","","","","","P0_MGMT_ASSERT_NMI_BTN_L",
 		/*32-39*/ "","P0_MGMT_SOC_RESET_L","",
 			"MGMT_HDT_SEL","","SCM_JTAG_DBREQ","","JTAG_TRST_N",
-		/*40-47*/ "","","","","","","","",
+		/*40-47*/ "","P0_MGMT_ASSERT_WARM_RST_BTN_L","","","","","","",
 		/*48-55*/ "","","","","","","","",
 		/*56-63*/ "","","","","","","","",
 		/*64-71*/ "","","","","","","","",

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -9,6 +9,8 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/i3c/i3c.h>
 
+//#define VERONA 1
+
 / {
 	model = "AMD Morocco VRB";
 	compatible = "amd,morocco-bmc", "aspeed,ast2700";
@@ -868,7 +870,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
-
+#ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
 		reg = <0x4c 0x224 0x00000001>;
 		assigned-address = <0x4c>;
@@ -877,6 +879,25 @@
 		reg = <0x3c 0x224 0x00000002>;
 		assigned-address = <0x3c>;
 	};
+#else
+	mctp-controller;
+
+	sbtsi_p0_0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_1: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
+	scoob_p0: scoob@5c,22400002118 {
+		reg = <0x5c 0x224 0x00002118>;
+		assigned-address = <0x5c>;
+	};
+#endif
+
 };
 
 &i3c5 {
@@ -885,7 +906,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
-
+#ifdef VERONA
 	sbtsi_p1_0: sbtsi@48,22400000001 {
 		reg = <0x48 0x224 0x00000001>;
 		assigned-address = <0x48>;
@@ -894,7 +915,27 @@
 		reg = <0x38 0x224 0x00000002>;
 		assigned-address = <0x38>;
 	};
+#else
+	mctp-controller;
+
+	sbtsi_p1_0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p1_1: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
+	scoob_p1: scoob@5c,22400002118 {
+		reg = <0x5c 0x224 0x00002118>;
+		assigned-address = <0x5c>;
+	};
+#endif
 };
+
+#ifdef I3C_HUB
 
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
@@ -954,6 +995,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	JESD300_SPD_I3C_MODE(1, 6, 56);
 	JESD300_SPD_I3C_MODE(1, 7, 57);
 };
+#endif
 
 &gpio0 {
 	status = "okay";
@@ -984,7 +1026,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*24-31*/ "","","","","","","","P0_MGMT_ASSERT_NMI_BTN_L",
 		/*32-39*/ "","P0_MGMT_SOC_RESET_L","",
 			"MGMT_HDT_SEL","","SCM_JTAG_DBREQ","","JTAG_TRST_N",
-		/*40-47*/ "","","","","","","","",
+		/*40-47*/ "","P0_MGMT_ASSERT_WARM_RST_BTN_L","","","","","","",
 		/*48-55*/ "","","","","","","","",
 		/*56-63*/ "","","","","","","","",
 		/*64-71*/ "","","","","","","","",

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -10,6 +10,7 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/i3c/i3c.h>
 
+//#define VERONA 1
 / {
 	model = "AMD Nigeria PRB";
 	compatible = "amd,nigeria-bmc", "aspeed,ast2700";
@@ -579,7 +580,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
-
+#ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
 		reg = <0x4c 0x224 0x00000001>;
 		assigned-address = <0x4c>;
@@ -588,6 +589,24 @@
 		reg = <0x3c 0x224 0x00000002>;
 		assigned-address = <0x3c>;
 	};
+#else
+	mctp-controller;
+
+	sbtsi_p0_0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_1: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
+	scoob_p0: scoob@5c,22400002118 {
+		reg = <0x5c 0x224 0x00002118>;
+		assigned-address = <0x5c>;
+	};
+#endif
 };
 
 &i3c5 {
@@ -596,6 +615,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
+#ifdef VERONA
 
 	sbtsi_p1_0: sbtsi@48,22400000001 {
 		reg = <0x48 0x224 0x00000001>;
@@ -605,7 +625,27 @@
 		reg = <0x38 0x224 0x00000002>;
 		assigned-address = <0x38>;
 	};
+#else
+	mctp-controller;
+
+	sbtsi_p1_0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p1_1: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
+	scoob_p1: scoob@5c,22400002118 {
+		reg = <0x5c 0x224 0x00002118>;
+		assigned-address = <0x5c>;
+	};
+#endif
 };
+
+#ifdef I3C_HUB
 
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
@@ -666,6 +706,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	JESD300_SPD_I3C_MODE(1, 6, 56);
 	JESD300_SPD_I3C_MODE(1, 7, 57);
 };
+#endif
 
 &gpio0 {
 	status = "okay";
@@ -696,7 +737,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*24-31*/ "","","","","","","","P0_MGMT_ASSERT_NMI_BTN_L",
 		/*32-39*/ "","P0_MGMT_SOC_RESET_L","",
 			"MGMT_HDT_SEL","","SCM_JTAG_DBREQ","","JTAG_TRST_N",
-		/*40-47*/ "","","","","","","","",
+		/*40-47*/ "","P0_MGMT_ASSERT_WARM_RST_BTN_L","","","","","","",
 		/*48-55*/ "","","","","","","","",
 		/*56-63*/ "","","","","","","","",
 		/*64-71*/ "","","","","","","","",


### PR DESCRIPTION
Add "P0_MGMT_ASSERT_WARM_RST_BTN_L" as LTPI GPIO
Add SBRMI and SBTSI new devices for i3c4 and i3c5

Tested: verified in Morocco with A1 BMC and Verona