### PR TITLE
linux:drivers: i3c and amd-apml driver for SP7 BU

### DIFF
--- a/drivers/i3c/device.c
+++ b/drivers/i3c/device.c
@@ -357,7 +357,7 @@ i3c_device_match_id(struct i3c_device *i3cdev,
 {
 	struct i3c_device_info devinfo;
 	const struct i3c_device_id *id;
-	u16 manuf, part, ext_info;
+	u16 manuf, part, ext_info, inst;
 	bool rndpid;
 
 	i3c_device_get_info(i3cdev, &devinfo);
@@ -365,7 +365,11 @@ i3c_device_match_id(struct i3c_device *i3cdev,
 	manuf = I3C_PID_MANUF_ID(devinfo.pid);
 	part = I3C_PID_PART_ID(devinfo.pid);
 	ext_info = I3C_PID_EXTRA_INFO(devinfo.pid);
+	inst = I3C_PID_INSTANCE_ID(devinfo.pid);
+	ext_info = ext_info | (inst << 12);
 	rndpid = I3C_PID_RND_LOWER_32BITS(devinfo.pid);
+
+	printk(" i3c_device_match_id: manuf 0x%x, part 0x%x, inst 0x%x, ext_info 0x%x \n", manuf, part, inst, ext_info);
 
 	for (id = id_table; id->match_flags != 0; id++) {
 		if ((id->match_flags & I3C_MATCH_DCR) &&

--- a/drivers/i3c/master/mipi-i3c-hci/core.c
+++ b/drivers/i3c/master/mipi-i3c-hci/core.c
@@ -357,7 +357,7 @@ static int i3c_hci_bus_init(struct i3c_master_controller *m)
 		return ret;
 
 	reg_set(HC_CONTROL, HC_CONTROL_BUS_ENABLE);
-	DBG("HC_CONTROL = %#x", reg_read(HC_CONTROL));
+	dev_info(&hci->master.dev, "HC_CONTROL = %#x", reg_read(HC_CONTROL));
 
 	return 0;
 }
@@ -474,7 +474,7 @@ static int i3c_hci_send_ccc_cmd(struct i3c_master_controller *m,
 	DECLARE_COMPLETION_ONSTACK(done);
 	int i, last, ret = 0;
 
-	DBG("cmd=%#x rnw=%d dbp=%d db=%#x ndests=%d data[0].len=%d", ccc->id,
+	dev_info(&hci->master.dev, "cmd=%#x rnw=%d dbp=%d db=%#x ndests=%d data[0].len=%d", ccc->id,
 	    ccc->rnw, ccc->dbp, ccc->db, ccc->ndests,
 	    ccc->dests[0].payload.len);
 
@@ -492,7 +492,10 @@ static int i3c_hci_send_ccc_cmd(struct i3c_master_controller *m,
 
 	xfer = hci_alloc_xfer(nxfers);
 	if (!xfer)
+	{
+		dev_info(&hci->master.dev,"hci_alloc_xfer error no mem \n");
 		return -ENOMEM;
+	}
 
 	if (prefixed) {
 		xfer->data = NULL;
@@ -525,6 +528,7 @@ static int i3c_hci_send_ccc_cmd(struct i3c_master_controller *m,
 		goto out;
 	if (!wait_for_completion_timeout(&done, HZ) &&
 	    hci->io->dequeue_xfer(hci, xfer, nxfers)) {
+		dev_info(&hci->master.dev,"dequeue_xfer error time out \n");
 		ret = -ETIME;
 		goto out;
 	}
@@ -533,18 +537,21 @@ static int i3c_hci_send_ccc_cmd(struct i3c_master_controller *m,
 			ccc->dests[i - prefixed].payload.len =
 				RESP_DATA_LENGTH(xfer[i].response);
 		if (RESP_STATUS(xfer[i].response) != RESP_SUCCESS) {
-			DBG("resp status = %lx", RESP_STATUS(xfer[i].response));
+			dev_info(&hci->master.dev, "resp status = %lx", RESP_STATUS(xfer[i].response));
 			if (RESP_STATUS(xfer[i].response) ==
 			    RESP_ERR_ADDR_HEADER)
 				ret = I3C_ERROR_M2;
 			else
+			{
+				dev_info(&hci->master.dev,"dequeue_xfer error IO \n");
 				ret = -EIO;
+			}
 			goto out;
 		}
 	}
 
 	if (ccc->rnw)
-		DBG("got: %*ph",
+		dev_info(&hci->master.dev, "got: %*ph",
 		    ccc->dests[0].payload.len, ccc->dests[0].payload.data);
 
 out:

--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -300,9 +300,13 @@ static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
 	};
 	struct regmap *regmap;
 
-	dev_info(dev, "SBTSI: PID: %llx\n", i3cdev->desc->info.pid);
-	if (!(i3cdev->desc->info.pid == 0x0 || i3cdev->desc->info.pid == 0x22400000001))
+	dev_err(dev, "SBTSI: PID: %llx\n", i3cdev->desc->info.pid);
+	if (!((i3cdev->desc->info.pid == 0x0) || (i3cdev->desc->info.pid == 0x22400000001) ||
+		(i3cdev->desc->info.pid == 0x118)))
+	{
+		dev_err(dev, "SBTSI: Error PID: %llx\n", i3cdev->desc->info.pid);
 		return -ENXIO;
+	}
 
 	regmap = devm_regmap_init_i3c(i3cdev, &sbtsi_i3c_regmap_config);
 	if (IS_ERR(regmap)) {
@@ -313,7 +317,10 @@ static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
 
 	tsi_dev = devm_kzalloc(dev, sizeof(struct apml_sbtsi_device), GFP_KERNEL);
 	if (!tsi_dev)
+	{
+		dev_err(dev, "SBTSI: Error Mem All0c\n");
 		return -ENOMEM;
+	}
 
 	tsi_dev->regmap = regmap;
 	mutex_init(&tsi_dev->lock);
@@ -323,7 +330,10 @@ static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
 							 &sbtsi_chip_info, NULL);
 
 	if (!hwmon_dev)
+	{
+		dev_err(dev, "SBTSI: Error hwmon_device_register \n" );
 		return PTR_ERR_OR_ZERO(hwmon_dev);
+	}
 
 	/* Need to verify for the static address for i3cdev */
 	tsi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
@@ -405,6 +415,8 @@ static void sbtsi_i2c_remove(struct i2c_client *client)
 }
 
 static const struct i3c_device_id sbtsi_i3c_id[] = {
+	I3C_DEVICE_EXTRA_INFO(0x112, 0, 0x118, NULL),
+	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x118, NULL),
 	I3C_DEVICE_EXTRA_INFO(0x112, 0, 0x1, NULL),
 	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
 	{}

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -45,6 +45,10 @@
 /* Two xfers, one write and one read require to read the data */
 #define I3C_I2C_MSG_XFER_SIZE		0x2
 
+/* DIMM temp */
+#define DIMM_BASE_ID          (0x80)
+#define DIMM_TEMP_OFFSET      (21)
+
 static int configure_regmap(struct apml_sbrmi_device *rmi_dev);
 
 enum sbrmi_msg_id {
@@ -52,6 +56,7 @@ enum sbrmi_msg_id {
 	SBRMI_WRITE_PKG_PWR_LIMIT,
 	SBRMI_READ_PKG_PWR_LIMIT,
 	SBRMI_READ_PKG_MAX_PWR_LIMIT,
+	SBRMI_READ_DIMM_THERMAL_SENSOR = 0x48,
 };
 
 static int sbrmi_get_max_pwr_limit(struct apml_sbrmi_device *rmi_dev)
@@ -76,7 +81,7 @@ static int sbrmi_read(struct device *dev, enum hwmon_sensor_types type,
 	struct apml_message msg = { 0 };
 	int ret = 0;
 
-	if (type != hwmon_power)
+	if ((type != hwmon_power) && (type != hwmon_temp))
 		return -EINVAL;
 	/* Configure regmap if not configured yet */
 	if (!rmi_dev->regmap) {
@@ -106,12 +111,31 @@ static int sbrmi_read(struct device *dev, enum hwmon_sensor_types type,
 		}
 		msg.data_out.mb_out[RD_WR_DATA_INDEX] = rmi_dev->pwr_limit_max;
 		break;
+	case hwmon_temp_input:
+		msg.cmd = SBRMI_READ_DIMM_THERMAL_SENSOR;
+		msg.data_in.mb_in[RD_WR_DATA_INDEX] = (DIMM_BASE_ID + channel);
+		ret = rmi_mailbox_xfer(rmi_dev, &msg);
+		if (ret < 0)
+			return ret;
+		break;
+
 	default:
 		ret = -EINVAL;
 	}
 	if (!ret)
-		/* hwmon power attributes are in microWatt */
-		*val = (long)msg.data_out.mb_out[RD_WR_DATA_INDEX] * 1000;
+	{
+		if (type == hwmon_power)
+		{
+			// hwmon power attributes are in microWatt
+			*val = (long)msg.data_out.mb_out[RD_WR_DATA_INDEX] * 1000;
+		}
+		else if (type == hwmon_temp)
+		{
+			// sbrmi temp is floating point, convert to deg C rational num
+			*val = (msg.data_out.mb_out[RD_WR_DATA_INDEX] >> DIMM_TEMP_OFFSET) * 1000;
+			*val = ((*val-32000) * (5/9));
+		}
+	}
 
 	mutex_unlock(&rmi_dev->lock);
 	return ret;
@@ -166,6 +190,12 @@ static umode_t sbrmi_is_visible(const void *data,
 			return 0644;
 		}
 		break;
+	case hwmon_temp:
+		switch (attr) {
+		case hwmon_temp_input:
+			return 0444;
+		}
+		break;
 	default:
 		break;
 	}
@@ -175,6 +205,11 @@ static umode_t sbrmi_is_visible(const void *data,
 static const struct hwmon_channel_info *sbrmi_info[] = {
 	HWMON_CHANNEL_INFO(power,
 			   HWMON_P_INPUT | HWMON_P_CAP | HWMON_P_CAP_MAX),
+	HWMON_CHANNEL_INFO(temp,
+		HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT,
+		HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT,
+		HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT,
+		HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT, HWMON_T_INPUT),
 	NULL
 };
 
@@ -541,12 +576,19 @@ static int sbrmi_i3c_probe(struct i3c_device *i3cdev)
 	struct apml_sbrmi_device *rmi_dev;
 
 	dev_info(dev, "SBRMI: PID: %llx\n", i3cdev->desc->info.pid);
-	if (!(i3cdev->desc->info.pid == 0x1000 || i3cdev->desc->info.pid == 0x22400000002))
+	if (!((i3cdev->desc->info.pid == 0x1000) || (i3cdev->desc->info.pid == 0x22400000002) ||
+	      (i3cdev->desc->info.pid == 0x1118)))
+	{
+		dev_info(dev, "SBRMI: PID Error: %llx\n", i3cdev->desc->info.pid);
 		return -ENXIO;
+	}
 
 	rmi_dev = devm_kzalloc(dev, sizeof(struct apml_sbrmi_device), GFP_KERNEL);
 	if (!rmi_dev)
+	{
+		dev_info(dev, "SBRMI: Error Mem Alloc\n");
 		return -ENOMEM;
+	}
 
 	atomic_set(&rmi_dev->in_progress, 0);
 	atomic_set(&rmi_dev->no_new_trans, 0);
@@ -559,7 +601,10 @@ static int sbrmi_i3c_probe(struct i3c_device *i3cdev)
 							 &sbrmi_chip_info, NULL);
 
 	if (!hwmon_dev)
+	{
+		dev_info(dev, "SBRMI: Error HWMON Device Register\n");
 		return PTR_ERR_OR_ZERO(hwmon_dev);
+	}
 
 	/* Need to verify for the static address for i3cdev */
 	rmi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
@@ -663,6 +708,8 @@ static const struct of_device_id __maybe_unused sbrmi_of_match[] = {
 MODULE_DEVICE_TABLE(of, sbrmi_of_match);
 
 static const struct i3c_device_id sbrmi_i3c_id[] = {
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x1118, NULL),
+	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x1118, NULL),
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x2, NULL),
 	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
 	{}


### PR DESCRIPTION
Add changes to handle the new device IDs for SP7
change i3c device.c
change amd-apml SBTSI and SBRMI driver
Add debug messages to mipi CCC cmd processing

Tested: verified in Congo A0 IOD, and Morocco A1 with Verona