### PR TITLE
ARM64:dts:aspeed Nigeria DTS changes for VRs

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -442,6 +442,30 @@
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			pvdd33_s5_p0@8{
+				compatible = "ism,ism6636a";
+				reg = <0x8>;
+			};
+                        pvdd33_s5_p0@12{
+                                compatible = "onsemi,fan251030";
+                                reg = <0x12>;
+                        };
+			pvddcr_cpu0_p0@61 {
+				//PVDDCR_CPU0_VDDIO_MEM_S3_P0_CONTROLLER
+				compatible = "mps,mp2856";
+				reg = <0x61>;
+			};
+			pvddcr_cpu1_p0@62 {
+				//PVDDCR_CPU1_PVDDCR_SOC_P0_CONTROLLER
+				compatible = "mps,mp2856";
+				reg = <0x62>;
+			};
+			pvddio_p0@63 {
+				//PVDDIO_P0_CONTROLLER
+				compatible = "mps,mp2856";
+				reg = <0x63>;
+			};
 		};
 
 		p0_sec: i2c@3 {
@@ -461,6 +485,27 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			p2v5_aux@9{
+				compatible = "ism,ism6636c";
+				reg = <0x9>;
+			};
+			p1v8_aux@a{
+				compatible = "ism,ism6636c";
+				reg = <0xa>;
+			};
+			p1v0_aux@b{
+				compatible = "ism,ism6636c";
+				reg = <0xb>;
+			};
+			p5v_aux@14{
+				compatible = "onsemi,fan251030";
+				reg = <0x14>;
+			};
+			p3v3_aux@15{
+				compatible = "onsemi,fan251030";
+				reg = <0x15>;
+			};
 		};
 
 		temp: i2c@1 {
@@ -564,6 +609,30 @@
                         reg = <2>;
                         #address-cells = <1>;
                         #size-cells = <0>;
+
+			pvdd33_s5_p1@9 {
+				compatible = "ism,ism6636a";
+				reg = <0x9>;
+			};
+			pvdd18_s5_p1@13{
+				compatible = "onsemi,fan251030";
+				reg = <0x13>;
+			};
+			pvddcr_cpu0_p1@64 {
+				//PVDDCR_CPU0_VDDIO_MEM_S3_P0_CONTROLLER
+				compatible = "mps,mp2856";
+				reg = <0x64>;
+			};
+			pvddcr_cpu1_p1@65 {
+				//PVDDCR_CPU1_PVDDCR_SOC_P0_CONTROLLER
+				compatible = "mps,mp2856";
+				reg = <0x65>;
+			};
+			pvddio_p1@66 {
+				//PVDDIO_P0_CONTROLLER
+				compatible = "mps,mp2856";
+				reg = <0x66>;
+			};
                 };
 
                 p1_sec: i2c@3 {
@@ -578,7 +647,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
@@ -613,7 +682,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 


### PR DESCRIPTION
- Add P0, P1, and System VRs for EVT2 and A1 BMC
- Increase APML I3C bus from 10 MHz to 12.5 MHz

tested: verified in Nigeria with A1 BMC