### PR TITLE
ARM64:dts:aspeed Kenya DTS changes for VRs

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -401,6 +401,27 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			p2v5_aux@8{
+				compatible = "ism,ism6636c";
+				reg = <0x8>;
+			};
+			p1v8_aux@9{
+				compatible = "ism,ism6636c";
+				reg = <0x9>;
+			};
+			p1v0_aux@a{
+				compatible = "ism,ism6636c";
+				reg = <0xa>;
+			};
+			p5v_aux@14{
+				compatible = "onsemi,fan251015";
+				reg = <0x14>;
+			};
+			p3v3_aux@15{
+				compatible = "onsemi,fan251015";
+				reg = <0x15>;
+			};
 		};
 
 		temp: i2c@1 {
@@ -468,6 +489,27 @@
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			pvdd33_s5_p0@8{
+				compatible = "ism,ism6636a";
+				reg = <0x8>;
+			};
+			pvdd18_s5_p0@12{
+				compatible = "onsemi,fan251030";
+				reg = <0x12>;
+			};
+			pvddcr_cpu0_p0@61{
+				compatible = "renesas,raa229639";
+				reg = <0x61>;
+			};
+			pvddcr_cpu1_p0@62{
+				compatible = "renesas,raa229639";
+				reg = <0x62>;
+			};
+			pvddio_p0@63{
+				compatible = "renesas,raa229641";
+				reg = <0x63>;
+			};
 		};
 
 		NC_2: i2c@3 {
@@ -482,7 +524,7 @@
         status = "okay";
         initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
         sbtsi_p0_0: sbtsi@4c,22400000001 {


### PR DESCRIPTION
- Added  P0 VRs and System VRs for EVT2 and A1 BMC
- increased APML Bus from 10 MHz to 12.5 MHz

tested: verified in Kenya with A1 BMC