### PR TITLE
ARM64:dts:aspeed Congo DTS set APML to 12.5 MHz

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -646,7 +646,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {


### PR DESCRIPTION
increase APML i3c bus from 10 MHz to 12.5 MHz

tested: verified in Congo FC with A1 BMC