### PR TITLE
ARM64:dts:aspeed Kenya DTS changes for VRs

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -84,6 +84,7 @@
 	};
 
 	aliases {
+#ifdef PDB
 		i2c100 = &riser_1A;
 		i2c101 = &riser_1B;
 		i2c102 = &riser_2A;
@@ -92,6 +93,7 @@
 		i2c105 = &m2;
 		i2c106 = &ocp;
 		i2c107 = &pdb;
+#endif
 		i2c108 = &mcio_1;
 		i2c109 = &mcio_2;
 		i2c110 = &mcio_3;
@@ -275,7 +277,7 @@
 		compatible = "microchip,24lc256","atmel,24c256";
 		reg = <0x50>;
 	};
-
+#ifdef PDB
 	i2cswitch@71 {
 		compatible = "nxp,pca9548";
 		reg = <0x71>;
@@ -330,7 +332,7 @@
 			#size-cells = <0>;
 		};
 	};
-
+#endif
 	i2cswitch@72 {
 		compatible = "nxp,pca9548";
 		reg = <0x72>;
@@ -401,6 +403,27 @@
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			p2v5_aux@8{
+				compatible = "ism,ism6636c";
+				reg = <0x8>;
+			};
+			p1v8_aux@9{
+				compatible = "ism,ism6636c";
+				reg = <0x9>;
+			};
+			p1v0_aux@a{
+				compatible = "ism,ism6636c";
+				reg = <0xa>;
+			};
+			p5v_aux@14{
+				compatible = "onsemi,fan251015";
+				reg = <0x14>;
+			};
+			p3v3_aux@15{
+				compatible = "onsemi,fan251015";
+				reg = <0x15>;
+			};
 		};
 
 		temp: i2c@1 {
@@ -468,6 +491,27 @@
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			pvdd33_s5_p0@8{
+				compatible = "ism,ism6636a";
+				reg = <0x8>;
+			};
+			pvdd18_s5_p0@12{
+				compatible = "onsemi,fan251030";
+				reg = <0x12>;
+			};
+			pvddcr_cpu0_p0@61{
+				compatible = "renesas,raa229639";
+				reg = <0x61>;
+			};
+			pvddcr_cpu1_p0@62{
+				compatible = "renesas,raa229639";
+				reg = <0x62>;
+			};
+			pvddio_p0@63{
+				compatible = "renesas,raa229641";
+				reg = <0x63>;
+			};
 		};
 
 		NC_2: i2c@3 {


### PR DESCRIPTION
Added P0 and System VRs for Kenya EVT2 with A1 BMC
(Temporary change, AI for Lenovo with CPLD ) Delete PDM Mux to avoid address conflict on i2c-8 

Tested 
- verified in Kenya EVT2 with A1 BMC