### PR TITLE
spi: aspeed: Add a dummy read for AST2700

### DIFF
--- a/drivers/spi/spi-aspeed-smc.c
+++ b/drivers/spi/spi-aspeed-smc.c
@@ -220,6 +220,7 @@ static void aspeed_spi_start_user(struct aspeed_spi_chip *chip)
 
 	ctl &= ~CTRL_CE_STOP_ACTIVE;
 	writel(ctl, chip->ctl);
+	readl(chip->ctl);
 }
 
 static void aspeed_spi_stop_user(struct aspeed_spi_chip *chip)


### PR DESCRIPTION
Add a dummy read in order to make sure the user mode is enabled actually. This modification doesn't affect on AST2500 or AST2600 platforms.


Change-Id: If4f87548bed651aff6c212e98df15b2fe4c2dfa0