### PR TITLE
ARM64:dts:aspeed Morocco DTS set APML to 12.5 MHz

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -868,7 +868,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
@@ -904,7 +904,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p1_0: sbtsi@48,22400000001 {


### PR DESCRIPTION
increase APML i3c bus fron 10 MHz to 12.5 MHz

tested: verified in Morocco FC with A1 BMC