### PR TITLE
ARM64:dts:aspeed: Removed SGPIO to enable NCSI

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -772,10 +772,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
                 /*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -652,10 +652,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1053,10 +1053,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-        status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -833,10 +833,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;


### PR DESCRIPTION
Removed SGPIO that claims NCSI pin control and blocks eth1 interface.