### PR TITLE
ARM64:dts:aspeed Nigeria DTS set SPI clk to 16 MHz

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -226,7 +226,7 @@
 		m25p,fast-read;
 		label = "pnor";
 		compatible = "jedec,spi-nor";
-		spi-max-frequency = <33000000>;
+		spi-max-frequency = <16000000>;
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <1>;
 	};


### PR DESCRIPTION
Reduce the SPI-2 controllers clock from 33 MHz to 16 MHz for local FPGA/BIOS flash updates.

tested: verified in Nigeria FC with A1 BMC