### PR TITLE
Apml tool enable for socket1

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -660,12 +660,17 @@
 #else
 	mctp-controller;
 
-	sbtsi_p0_0: sbtsi@4c,22400000118 {
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
 		reg = <0x4c 0x224 0x00000118>;
 		assigned-address = <0x4c>;
 	};
 
-	sbrmi_p0_1: sbrmi@3c,22400001118 {
+	sbtsi_p0_iod1: sbtsi@44,22400010118 {
+		reg = <0x44 0x224 0x00010118>;
+		assigned-address = <0x44>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;
 	};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -882,12 +882,17 @@
 #else
 	mctp-controller;
 
-	sbtsi_p0_0: sbtsi@4c,22400000118 {
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
 		reg = <0x4c 0x224 0x00000118>;
 		assigned-address = <0x4c>;
 	};
 
-	sbrmi_p0_1: sbrmi@3c,22400001118 {
+	sbtsi_p0_iod1: sbtsi@44,22400010118 {
+		reg = <0x44 0x224 0x00010118>;
+		assigned-address = <0x44>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;
 	};
@@ -897,7 +902,6 @@
 		assigned-address = <0x5c>;
 	};
 #endif
-
 };
 
 &i3c5 {
@@ -918,19 +922,24 @@
 #else
 	mctp-controller;
 
-	sbtsi_p1_0: sbtsi@4c,22400000118 {
-		reg = <0x4c 0x224 0x00000118>;
-		assigned-address = <0x4c>;
+	sbtsi_p1_iod0: sbtsi@48,22401000118 {
+		reg = <0x48 0x224 0x01000118>;
+		assigned-address = <0x48>;
 	};
 
-	sbrmi_p1_1: sbrmi@3c,22400001118 {
-		reg = <0x3c 0x224 0x00001118>;
-		assigned-address = <0x3c>;
+	sbtsi_p1_iod1: sbtsi@45,22401010118 {
+		reg = <0x45 0x224 0x01010118>;
+		assigned-address = <0x45>;
 	};
 
-	scoob_p1: scoob@5c,22400002118 {
-		reg = <0x5c 0x224 0x00002118>;
-		assigned-address = <0x5c>;
+	sbrmi_p1_iod0: sbrmi@38,22401011118 {
+		reg = <0x38 0x224 0x01011118>;
+		assigned-address = <0x38>;
+	};
+
+	scoob_p1: scoob@55,22401012118 {
+		reg = <0x55 0x224 0x01012118>;
+		assigned-address = <0x55>;
 	};
 #endif
 };

--- a/drivers/i3c/master/mipi-i3c-hci/core.c
+++ b/drivers/i3c/master/mipi-i3c-hci/core.c
@@ -1384,6 +1384,7 @@ static int i3c_hci_init(struct i3c_hci *hci)
 		return -EINVAL;
 	}
 
+#if 0
 	/* Try activating DMA operations first */
 	if (hci->RHS_regs) {
 		reg_clear(HC_CONTROL, HC_CONTROL_PIO_MODE);
@@ -1400,6 +1401,7 @@ static int i3c_hci_init(struct i3c_hci *hci)
 			dev_info(&hci->master.dev, "Using DMA\n");
 		}
 	}
+#endif
 
 	/* If no DMA, try PIO */
 	if (!hci->io && hci->PIO_regs) {

--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -302,7 +302,8 @@ static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
 
 	dev_err(dev, "SBTSI: PID: %llx\n", i3cdev->desc->info.pid);
 	if (!((i3cdev->desc->info.pid == 0x0) || (i3cdev->desc->info.pid == 0x22400000001) ||
-		(i3cdev->desc->info.pid == 0x118)))
+		(i3cdev->desc->info.pid == 0x118) || (i3cdev->desc->info.pid == 0x010118) ||
+		(i3cdev->desc->info.pid == 0x01000118) || (i3cdev->desc->info.pid == 0x01010118)))
 	{
 		dev_err(dev, "SBTSI: Error PID: %llx\n", i3cdev->desc->info.pid);
 		return -ENXIO;
@@ -415,8 +416,11 @@ static void sbtsi_i2c_remove(struct i2c_client *client)
 }
 
 static const struct i3c_device_id sbtsi_i3c_id[] = {
-	I3C_DEVICE_EXTRA_INFO(0x112, 0, 0x118, NULL),
-	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x118, NULL),
+                    /* (MID, PARTID, EXTIN, DRVDATA) */
+	I3C_DEVICE_EXTRA_INFO(0, 0x0000, 0x118, NULL), /* P0 - IOD0 - SBTSI */
+	I3C_DEVICE_EXTRA_INFO(0, 0x0001, 0x118, NULL), /* P0 - IOD1 - SBTST */
+	I3C_DEVICE_EXTRA_INFO(0, 0x0100, 0x118, NULL), /* P1 - IOD0 - SBTSI */
+	I3C_DEVICE_EXTRA_INFO(0, 0x0101, 0x118, NULL), /* P1 - IOD1 - SBTSI */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0, 0x1, NULL),
 	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
 	{}

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -611,7 +611,7 @@ static int sbrmi_i3c_probe(struct i3c_device *i3cdev)
 
 	dev_info(dev, "SBRMI: PID: %llx\n", i3cdev->desc->info.pid);
 	if (!((i3cdev->desc->info.pid == 0x1000) || (i3cdev->desc->info.pid == 0x22400000002) ||
-	      (i3cdev->desc->info.pid == 0x1118)))
+		(i3cdev->desc->info.pid == 0x1118) || (i3cdev->desc->info.pid == 0x1001118)))
 	{
 		dev_info(dev, "SBRMI: PID Error: %llx\n", i3cdev->desc->info.pid);
 		return -ENXIO;
@@ -752,8 +752,8 @@ static const struct of_device_id __maybe_unused sbrmi_of_match[] = {
 MODULE_DEVICE_TABLE(of, sbrmi_of_match);
 
 static const struct i3c_device_id sbrmi_i3c_id[] = {
-	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x1118, NULL),
-	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x1118, NULL),
+	I3C_DEVICE_EXTRA_INFO(0, 0x000, 0x1118, NULL), /* P0 - IOD0 - SBRMI */
+	I3C_DEVICE_EXTRA_INFO(0, 0x100, 0x1118, NULL), /* P1 - IOD0 - SBRMI */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x2, NULL),
 	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
 	{}


### PR DESCRIPTION
Following changes are done:
- mipi core driver is forced to initialize in the PIO mode since the DMA is failing in the register block read operation
- modify sbtsi/sbrmi drivers device info tables to include sbtsi on iod1, and sbtsi/sbrmi for socket1
- modify the Congo and Morocco device trees.

tested: verified on Congo and Morocco with Aspeed A1.