### PR TITLE
ARM64:dts:aspeed Nigeria DTS changes for socket1

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -661,12 +661,17 @@
 #else
 	mctp-controller;
 
-	sbtsi_p0_0: sbtsi@4c,22400000118 {
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
 		reg = <0x4c 0x224 0x00000118>;
 		assigned-address = <0x4c>;
 	};
 
-	sbrmi_p0_1: sbrmi@3c,22400001118 {
+	sbtsi_p0_iod1: sbtsi@44,22400010118 {
+		reg = <0x44 0x224 0x00010118>;
+		assigned-address = <0x44>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;
 	};
@@ -685,7 +690,6 @@
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
-
 	sbtsi_p1_0: sbtsi@48,22400000001 {
 		reg = <0x48 0x224 0x00000001>;
 		assigned-address = <0x48>;
@@ -697,19 +701,24 @@
 #else
 	mctp-controller;
 
-	sbtsi_p1_0: sbtsi@4c,22400000118 {
-		reg = <0x4c 0x224 0x00000118>;
-		assigned-address = <0x4c>;
+	sbtsi_p1_iod0: sbtsi@48,22401000118 {
+		reg = <0x48 0x224 0x01000118>;
+		assigned-address = <0x48>;
 	};
 
-	sbrmi_p1_1: sbrmi@3c,22400001118 {
-		reg = <0x3c 0x224 0x00001118>;
-		assigned-address = <0x3c>;
+	sbtsi_p1_iod1: sbtsi@45,22401010118 {
+		reg = <0x45 0x224 0x01010118>;
+		assigned-address = <0x45>;
 	};
 
-	scoob_p1: scoob@5c,22400002118 {
-		reg = <0x5c 0x224 0x00002118>;
-		assigned-address = <0x5c>;
+	sbrmi_p1_iod0: sbrmi@38,22401011118 {
+		reg = <0x38 0x224 0x01011118>;
+		assigned-address = <0x38>;
+	};
+
+	scoob_p1: scoob@55,22401012118 {
+		reg = <0x55 0x224 0x01012118>;
+		assigned-address = <0x55>;
 	};
 #endif
 };


### PR DESCRIPTION
add details of sbtsi slave address and PID of SBTSI device on IOD0/1 on socket0/1 to the Nigeria device tree to allow the drivers to probe the devices and create device nodes needed for apml_tool.

Testd:
- verified on Nigeria EVT2 with A1 BMC