### PR TITLE
ARM64:dts:aspeed Kenya DTS changes for iod1/sbtsi

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -523,29 +523,34 @@
 };
 
 &i3c4 {
-        status = "okay";
-        initial-role = "primary";
+	status = "okay";
+	initial-role = "primary";
 	internal-pullup = <2>;
 	i3c-scl-hz = <10000000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
-        sbtsi_p0_0: sbtsi@4c,22400000001 {
-                reg = <0x4c 0x224 0x00000001>;
-                assigned-address = <0x4c>;
-        };
-        sbrmi_p0_1: sbrmi@3c,22400000002 {
-                reg = <0x3c 0x224 0x00000002>;
-                assigned-address = <0x3c>;
-        };
+	sbtsi_p0_0: sbtsi@4c,22400000001 {
+		reg = <0x4c 0x224 0x00000001>;
+		assigned-address = <0x4c>;
+	};
+	sbrmi_p0_1: sbrmi@3c,22400000002 {
+		reg = <0x3c 0x224 0x00000002>;
+		assigned-address = <0x3c>;
+	};
 #else
 	mctp-controller;
 
-	sbtsi_p0_0: sbtsi@4c,22400000118 {
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
 		reg = <0x4c 0x224 0x00000118>;
 		assigned-address = <0x4c>;
 	};
 
-	sbrmi_p0_1: sbrmi@3c,22400001118 {
+	sbtsi_p0_iod1: sbtsi@44,22400010118 {
+		reg = <0x44 0x224 0x00010118>;
+		assigned-address = <0x44>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;
 	};


### PR DESCRIPTION
add details of sbtsi slave address and PID of SBTSI device on IOD1 on socket0 to the Kenya device tree to allow the drivers to probe the device and create device node needed for apml_tool.

Testd:
- verified on Kenya EVT2 with A1 BMC