### PR TITLE
Revert "ARM64:dts:aspeed: Removed SGPIO to enable NCSI"

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -963,6 +963,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
                 /*216-223*/ "","","","","","","","";
 };
 
+&sgpios {
+	status = "okay";
+};
+
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -657,6 +657,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
+&sgpios {
+	status = "okay";
+};
+
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1062,6 +1062,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
+&sgpios {
+        status = "okay";
+};
+
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -842,6 +842,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
+&sgpios {
+	status = "okay";
+};
+
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;


### PR DESCRIPTION
Reverts AMDESE/linux-aspeed#102 