### PR TITLE
arm64:dts:aspeed Add syscon0 to bmc_dev0

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
+++ b/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
@@ -501,6 +501,7 @@
 			aspeed,config = <&pcie_config0>;
 			aspeed,device = <&pcie_device0>;
 			aspeed,e2m = <&e2m_config0>;
+			aspeed,scu = <&syscon0>;
 			pcie2lpc;
 			status = "disabled";
 		};


### PR DESCRIPTION
Per Aspeed recommandation:
- Add syscon0 to bmc_dev0 in g7 dtsi for BMC Device driver to work properly

Tested:
- verified in Congo RevA with fused IOD