### PR TITLE
arm64: aspeed: add scu handle for bmc_dev

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
+++ b/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
@@ -501,6 +501,7 @@
 			aspeed,config = <&pcie_config0>;
 			aspeed,device = <&pcie_device0>;
 			aspeed,e2m = <&e2m_config0>;
+			aspeed,scu = <&syscon0>;
 			pcie2lpc;
 			status = "disabled";
 		};
@@ -513,6 +514,7 @@
 			aspeed,config = <&pcie_config1>;
 			aspeed,device = <&pcie_device1>;
 			aspeed,e2m = <&e2m_config1>;
+			aspeed,scu = <&syscon0>;
 			pcie2lpc;
 			status = "disabled";
 		};


### PR DESCRIPTION
Because the BMC device needs to use chip version to
configure MSI capability, set scu property for bmc_dev.

Signed-off-by: Jacky Chou <jacky_chou@aspeedtech.com>