### PR TITLE
ARM64:dts:aspeed: Removed SGPIO to enable NCSI

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -977,10 +977,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
                 /*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -657,10 +657,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1087,10 +1087,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-        status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -842,10 +842,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&sgpios {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;


### PR DESCRIPTION
Removed SGPIO that claims NCSI pin control and blocks eth1 interface.

Tested on:
-Congo RevA with A1 BMC
-Morocco RevA with A1 BMC
-Kenya EVT2 with A1 BMC
-Nigeria EVT2 with A1 BMC