### PR TITLE
drivers:hwmon: Replace SMBus block read

### DIFF
--- a/drivers/hwmon/pmbus/fan251030.c
+++ b/drivers/hwmon/pmbus/fan251030.c
@@ -39,13 +39,14 @@ static int fan251030_probe(struct i2c_client *client)
 	if (!i2c_check_functionality(client->adapter,
 				     I2C_FUNC_SMBUS_READ_BYTE_DATA |
 				     I2C_FUNC_SMBUS_READ_WORD_DATA |
-				     I2C_FUNC_SMBUS_READ_BLOCK_DATA))
+				     I2C_FUNC_SMBUS_READ_BLOCK_DATA |
+				     I2C_FUNC_SMBUS_READ_I2C_BLOCK))
 	{
 		dev_err(&client->dev, "fan251030_probe: Error i2c_check_functionality\n");
 		return -ENODEV;
 	}
 	/* Read Manufacturer id */
-	ret = i2c_smbus_read_block_data(client, PMBUS_IC_DEVICE_ID, buf);
+	ret = i2c_smbus_read_i2c_block_data(client, PMBUS_IC_DEVICE_ID, I2C_SMBUS_BLOCK_DATA, buf);
 	if (ret < 0) {
 		dev_err(&client->dev, "fan251030_probe: Failed to read PMBUS_IC_DEVICE_ID\n");
 		return ret;

--- a/drivers/hwmon/pmbus/raa229126.c
+++ b/drivers/hwmon/pmbus/raa229126.c
@@ -56,14 +56,15 @@ static int raa229126_probe(struct i2c_client *client)
 	if (!i2c_check_functionality(client->adapter,
 				     I2C_FUNC_SMBUS_READ_BYTE_DATA |
 				     I2C_FUNC_SMBUS_READ_WORD_DATA |
-				     I2C_FUNC_SMBUS_READ_BLOCK_DATA))
+				     I2C_FUNC_SMBUS_READ_BLOCK_DATA |
+				     I2C_FUNC_SMBUS_READ_I2C_BLOCK))
 	{
 		dev_err(&client->dev, "raa229126_probe: error in i2c_check_functionality\n");
 		return -ENODEV;
 	}
 
 	/* Read Manufacturer id */
-	ret = i2c_smbus_read_block_data(client, PMBUS_IC_DEVICE_ID, buf);
+	ret = i2c_smbus_read_i2c_block_data(client, PMBUS_IC_DEVICE_ID, I2C_SMBUS_BLOCK_DATA, buf);
 	if (ret < 0) {
 		dev_err(&client->dev, "Failed to read PMBUS_IC_DEVICE_ID\n");
 		return ret;


### PR DESCRIPTION
The SMBus block read was returning -EOVERFLOW (-74) due to the device possibly returning an invalid or unexpected length byte. Replaced it with i2c_smbus_read_i2c_block_data() to directly read 4 bytes from PMBUS_IC_DEVICE_ID, which aligns with the device's actual behavior and resolves the error.

Tested fields: Verified in Congo and Kenya platform.