### PR TITLE
ARM64:dts:aspeed: Add eSPI eDAF and PCC nodes for AMD platforms

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -86,6 +86,11 @@
 			no-map;
 		};
 
+		espi0_mmbi_memory: espi0-mmbi-memory@424000000 {
+			reg = <0x4 0x24000000 0x0 0x4000000>;
+			no-map;
+		};
+
 		mctp0_reserved: mctp0_reserved@431080000 {
 			reg = <0x4 0x31080000 0x0 0x10000>;
 			compatible = "shared-dma-pool";
@@ -233,7 +238,7 @@
 
 	flash@0 {
 		reg = <0>;
- 		status = "okay";
+		status = "okay";
 		m25p,fast-read;
 		label = "pnor";
 		compatible = "jedec,spi-nor";
@@ -948,12 +953,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		line-name = "SEL_P0_SEC_I2C_ROT_BMC";
 	};
 
-	espi_default {
-		gpio-hog;
-		gpios = <10 GPIO_ACTIVE_HIGH>;
-		output-low;
-		line-name = "espiboot_pin_default";
-	};
 };
 
 &ltpi0 {
@@ -1010,8 +1009,18 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 &espi0 {
 	status = "okay";
 	perif-dma-mode;
+	perif-mmbi-enable;
+	perif-mmbi-src-addr = <0x0 0xa8000000>;
+	perif-mmbi-tgt-memory = <&espi0_mmbi_memory>;
+	perif-mmbi-instance-num = <0x1>;
+	perif-mcyc-enable;
+	perif-mcyc-src-addr = <0x0 0x98000000>;
+	perif-mcyc-size = <0x0 0x10000>;
 	oob-dma-mode;
 	flash-dma-mode;
+	flash-edaf-mode = <0>;
+	flash-edaf-tgt-addr = <0x1 0x80000000>;
+	flash-edaf-size = <0x0 0x2000000>;
 };
 
 &lpc0_pcc {
@@ -1036,6 +1045,15 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	/delete-property/ pinctrl-names;
 	/delete-property/ pinctrl-0;
 	status = "okay";
+};
+
+/* eSPI VUART */
+&vuart0 {
+	status = "okay";
+	virtual;
+	port = <0x3f8>;
+	sirq = <4>;
+	sirq-polarity = <0>;
 };
 
 &uphy3a {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -81,6 +81,11 @@
 			compatible = "shared-dma-pool";
 			no-map;
 		};
+
+		espi0_mmbi_memory: espi0-mmbi-memory@424000000 {
+			reg = <0x4 0x24000000 0x0 0x4000000>;
+			no-map;
+		};
 	};
 
 	aliases {
@@ -629,13 +634,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
                 output-high;
                 line-name = "SEL_P0_SEC_I2C_ROT_BMC";
         };
-
-	espi_default {
-		gpio-hog;
-		gpios = <10 GPIO_ACTIVE_HIGH>;
-		output-low;
-		line-name = "espiboot_pin_default";
-	};
 };
 
 &ltpi0 {
@@ -692,8 +690,18 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 &espi0 {
 	status = "okay";
 	perif-dma-mode;
+	perif-mmbi-enable;
+	perif-mmbi-src-addr = <0x0 0xa8000000>;
+	perif-mmbi-tgt-memory = <&espi0_mmbi_memory>;
+	perif-mmbi-instance-num = <0x1>;
+	perif-mcyc-enable;
+	perif-mcyc-src-addr = <0x0 0x98000000>;
+	perif-mcyc-size = <0x0 0x10000>;
 	oob-dma-mode;
 	flash-dma-mode;
+	flash-edaf-mode = <0>;
+	flash-edaf-tgt-addr = <0x1 0x80000000>;
+	flash-edaf-size = <0x0 0x2000000>;
 };
 
 &lpc0_pcc {
@@ -717,6 +725,15 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	/delete-property/ pinctrl-names;
 	/delete-property/ pinctrl-0;
 	status = "okay";
+};
+
+/* eSPI VUART */
+&vuart0 {
+	status = "okay";
+	virtual;
+	port = <0x3f8>;
+	sirq = <4>;
+	sirq-polarity = <0>;
 };
 
 &uphy3a {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -81,6 +81,11 @@
 			no-map;
 		};
 
+		espi0_mmbi_memory: espi0-mmbi-memory@424000000 {
+			reg = <0x4 0x24000000 0x0 0x4000000>;
+			no-map;
+		};
+
 		mctp0_reserved: mctp0_reserved@431080000 {
 			reg = <0x4 0x31080000 0x0 0x10000>;
 			compatible = "shared-dma-pool";
@@ -1072,13 +1077,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		output-high;
 		line-name = "SEL_P1_SEC_I2C_ROT_BMC";
 	};
-
-	espi_default {
-		gpio-hog;
-		gpios = <10 GPIO_ACTIVE_HIGH>;
-		output-low;
-		line-name = "espiboot_pin_default";
-	};
 };
 
 &ltpi0 {
@@ -1135,14 +1133,47 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	memory-region = <&video_engine_memory0>;
 };
 
+/* eSPI node for P0 - PCC, eDAF enabled */
 &espi0 {
+   status = "okay";
+   perif-dma-mode;
+   perif-mmbi-enable;
+   perif-mmbi-src-addr = <0x0 0xa8000000>;
+   perif-mmbi-tgt-memory = <&espi0_mmbi_memory>;
+   perif-mmbi-instance-num = <0x1>;
+   perif-mcyc-enable;
+   perif-mcyc-src-addr = <0x0 0x98000000>;
+   perif-mcyc-size = <0x0 0x10000>;
+   oob-dma-mode;
+   flash-dma-mode;
+   flash-edaf-mode = <0>;
+   flash-edaf-tgt-addr = <0x1 0x80000000>;
+   flash-edaf-size = <0x0 0x2000000>;
+};
+
+/* eSPI node for P1 - PCC only */
+&espi1 {
 	status = "okay";
 	perif-dma-mode;
 	oob-dma-mode;
 	flash-dma-mode;
 };
 
+/* Post code capture for P0 */
 &lpc0_pcc {
+	port-addr = <0x80>;
+	dma-mode;
+	A2600-15;
+	memory-region = <&pcc_memory>;
+	rec-mode = <0x1>;
+	port-addr-hbits-select = <0x1>;
+	port-addr-xbits = <0x3>;
+
+	status = "okay";
+};
+
+/* Post code capture for P1 */
+&lpc1_pcc {
 	port-addr = <0x80>;
 	dma-mode;
 	A2600-15;
@@ -1164,6 +1195,24 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	/delete-property/ pinctrl-names;
 	/delete-property/ pinctrl-0;
 	status = "okay";
+};
+
+/* eSPI VUART P0 */
+&vuart0 {
+	status = "okay";
+	virtual;
+	port = <0x3f8>;
+	sirq = <4>;
+	sirq-polarity = <0>;
+};
+
+/* eSPI VUART P1 */
+&vuart2{
+	status = "okay";
+	virtual;
+	port = <0x3f8>;
+	sirq = <4>;
+	sirq-polarity = <0>;
 };
 
 &uphy3a {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -80,6 +80,11 @@
 			compatible = "shared-dma-pool";
 			no-map;
 		};
+
+		espi0_mmbi_memory: espi0-mmbi-memory@424000000 {
+			reg = <0x4 0x24000000 0x0 0x4000000>;
+			no-map;
+		};
 	};
 
 	aliases {
@@ -902,13 +907,33 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	memory-region = <&video_engine_memory0>;
 };
 
+/* eSPI node for P0 - PCC, eDAF enabled */
 &espi0 {
+   status = "okay";
+   perif-dma-mode;
+   perif-mmbi-enable;
+   perif-mmbi-src-addr = <0x0 0xa8000000>;
+   perif-mmbi-tgt-memory = <&espi0_mmbi_memory>;
+   perif-mmbi-instance-num = <0x1>;
+   perif-mcyc-enable;
+   perif-mcyc-src-addr = <0x0 0x98000000>;
+   perif-mcyc-size = <0x0 0x10000>;
+   oob-dma-mode;
+   flash-dma-mode;
+   flash-edaf-mode = <0>;
+   flash-edaf-tgt-addr = <0x1 0x80000000>;
+   flash-edaf-size = <0x0 0x2000000>;
+};
+
+/* eSPI node for P1 - PCC only */
+&espi1 {
 	status = "okay";
 	perif-dma-mode;
 	oob-dma-mode;
 	flash-dma-mode;
 };
 
+/* Post code capture for P0 */
 &lpc0_pcc {
 	port-addr = <0x80>;
 	dma-mode;
@@ -916,6 +941,20 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	rec-mode = <0x1>;
 	port-addr-hbits-select = <0x1>;
 	port-addr-xbits = <0x3>;
+
+	status = "okay";
+};
+
+/* Post code capture for P1 */
+&lpc1_pcc {
+	port-addr = <0x80>;
+	dma-mode;
+	A2600-15;
+	memory-region = <&pcc_memory>;
+	rec-mode = <0x1>;
+	port-addr-hbits-select = <0x1>;
+	port-addr-xbits = <0x3>;
+
 	status = "okay";
 };
 
@@ -929,6 +968,24 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	/delete-property/ pinctrl-names;
 	/delete-property/ pinctrl-0;
 	status = "okay";
+};
+
+/* eSPI VUART P0 */
+&vuart0 {
+	status = "okay";
+	virtual;
+	port = <0x3f8>;
+	sirq = <4>;
+	sirq-polarity = <0>;
+};
+
+/* eSPI VUART P1 */
+&vuart2{
+	status = "okay";
+	virtual;
+	port = <0x3f8>;
+	sirq = <4>;
+	sirq-polarity = <0>;
 };
 
 &uphy3a {


### PR DESCRIPTION
- enabled eDAF for Congo, Morocco, Kenya and Nigeria
- enabled eSPI controller for P1 (2P platforms)
- enabled eSPI PCC for P1 (2P platforms)
- removed gpio-hog pinmux configs (handled in u-boot)

Tested: Verified eDAF in Congo and Post codes for Morocco.
	Verified tty devices created for eSPI vuart