### PR TITLE
ARM64:dts:aspeed Morocco DTS added i2c3 for fpga_i2c<3>

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -263,6 +263,12 @@
         status = "okay";
 };
 
+&i2c3 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+        status = "okay";
+};
+
 // I2C configs
 &i2c7 {
 	status = "okay";


### PR DESCRIPTION
Added i2c3 to enable access to fpga_i2c<3> bus
via i2c over ltpi

Tested:verified on Morocco A1 BMC