### PR TITLE
ARM64:dts:aspeed Morocco and Nigeria DTS changes for P1_APML_ALERT_L

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1111,7 +1111,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*88-95*/ "","","","","","","","P1_MGMT_ASSERT_WARM_RST_BTN_L",
 		/*96-103*/ "","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","",
 			"P1_MGMT_ASSERT_CLR_CMOS","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
-		/*104-111*/ "","","","","","HPM_STBY_EN","","",
+		/*104-111*/ "P1_I3C_APML_ALERT_L","","","","","HPM_STBY_EN","","",
 		/*112-119*/ "","","","","","","","",
 		/*120-127*/ "","","","","","","","",
 		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -878,7 +878,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*88-95*/ "","","","","","","","P1_MGMT_ASSERT_WARM_RST_BTN_L",
 		/*96-103*/ "","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","",
 			"P1_MGMT_ASSERT_CLR_CMOS","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
-		/*104-111*/ "","","","","","HPM_STBY_EN","","",
+		/*104-111*/ "P1_I3C_APML_ALERT_L","","","","","HPM_STBY_EN","","",
 		/*112-119*/ "","","","","","","","",
 		/*120-127*/ "","","","","","","","",
 		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",


### PR DESCRIPTION
Added "P1_I3C_APML_ALERT_L" label at index 104 in ltpi0_gpio

Tested fields: Verified in Morocco platform.