### PR TITLE
ARM64:dts:aspeed add overlays to spi2

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -234,11 +234,10 @@
 	status = "okay";
 	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_spi2_cs1_default>;
 	pinctrl-names = "default";
-	compatible = "aspeed,ast2700-spi";
-
+	compatible = "aspeed,ast2700-spi-txrx";
 	flash@0 {
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 		m25p,fast-read;
 		label = "pnor";
 		compatible = "jedec,spi-nor";
@@ -246,6 +245,15 @@
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <1>;
 	};
+	oled@0 {
+        reg = < 0 >; // Chip select 0
+        compatible = "ssd,ssd1322";
+        spi-max-frequency = <1000000>; // Adjust the frequency as needed
+        label = "ssd1322";
+        status = "okay"; // Enable the SSD1322 device
+        spi-tx-bus-width = <1>;
+        spi-rx-bus-width = <1>;
+    };
 };
 
 //BMC Console

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -217,11 +217,10 @@
 	status = "okay";
 	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_spi2_cs1_default>;
 	pinctrl-names = "default";
-	compatible = "aspeed,ast2700-spi";
-
+	compatible = "aspeed,ast2700-spi-txrx";
 	flash@0 {
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 		m25p,fast-read;
 		label = "pnor";
 		compatible = "jedec,spi-nor";
@@ -229,6 +228,15 @@
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <1>;
 	};
+	oled@0 {
+        reg = < 0 >; // Chip select 0
+        compatible = "ssd,ssd1322";
+        spi-max-frequency = <1000000>; // Adjust the frequency as needed
+        label = "ssd1322";
+        status = "okay"; // Enable the SSD1322 device
+        spi-tx-bus-width = <1>;
+        spi-rx-bus-width = <1>;
+    };
 };
 
 //BMC Console

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -243,11 +243,10 @@
 	status = "okay";
 	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_spi2_cs1_default>;
 	pinctrl-names = "default";
-	compatible = "aspeed,ast2700-spi";
-
+	compatible = "aspeed,ast2700-spi-txrx";
 	flash@0 {
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 		m25p,fast-read;
 		label = "pnor";
 		compatible = "jedec,spi-nor";
@@ -255,6 +254,15 @@
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <1>;
 	};
+	oled@0 {
+        reg = < 0 >; // Chip select 0
+        compatible = "ssd,ssd1322";
+        spi-max-frequency = <1000000>; // Adjust the frequency as needed
+        label = "ssd1322";
+        status = "okay"; // Enable the SSD1322 device
+        spi-tx-bus-width = <1>;
+        spi-rx-bus-width = <1>;
+    };
 };
 
 //BMC Console

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -223,11 +223,10 @@
 	status = "okay";
 	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_spi2_cs1_default>;
 	pinctrl-names = "default";
-	compatible = "aspeed,ast2700-spi";
-
+	compatible = "aspeed,ast2700-spi-txrx";
 	flash@0 {
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 		m25p,fast-read;
 		label = "pnor";
 		compatible = "jedec,spi-nor";
@@ -235,6 +234,15 @@
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <1>;
 	};
+	oled@0 {
+        reg = < 0 >; // Chip select 0
+        compatible = "ssd,ssd1322";
+        spi-max-frequency = <1000000>; // Adjust the frequency as needed
+        label = "ssd1322";
+        status = "okay"; // Enable the SSD1322 device
+        spi-tx-bus-width = <1>;
+        spi-rx-bus-width = <1>;
+    };
 };
 
 //BMC Console

--- a/arch/arm64/boot/dts/aspeed/overlays/spi-nor-overlay.dts
+++ b/arch/arm64/boot/dts/aspeed/overlays/spi-nor-overlay.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    fragment@0 {
+        target-path = "/soc@14000000/spi@14030000";
+        __overlay__ {
+            compatible = "aspeed,ast2700-spi";  // Change the SPI controller driver
+            status = "okay";
+        };
+    };
+
+    fragment@1 {
+        target-path = "/soc@14000000/spi@14030000/flash@0";
+        __overlay__ {
+            status = "okay"; // Enable the NOR flash
+        };
+    };
+    
+    fragment@2 {
+        target-path = "/soc@14000000/spi@14030000/oled@0";
+        __overlay__ {
+            status = "disabled"; // Disable the OLED
+        };
+    };
+};

--- a/arch/arm64/boot/dts/aspeed/overlays/spi-oled-overlay.dts
+++ b/arch/arm64/boot/dts/aspeed/overlays/spi-oled-overlay.dts
@@ -1,0 +1,26 @@
+/dts-v1/;
+/plugin/;
+
+/ {
+    fragment@0 {
+        target-path = "/soc@14000000/spi@14030000";
+        __overlay__ {
+            compatible = "aspeed,ast2700-spi-txrx";  // Change the SPI controller driver
+            status = "okay";
+        };
+    };
+
+    fragment@1 {
+        target-path = "/soc@14000000/spi@14030000/oled@0";
+        __overlay__ {
+            status = "okay"; // Enable the OLED
+        };
+    };
+
+    fragment@2 {
+        target-path = "/soc@14000000/spi@14030000/flash@0";
+        __overlay__ {
+            status = "disabled"; // Disable the NOR flash
+        };
+    };
+};


### PR DESCRIPTION
Added overlays to enable switching between LCD and FW EEPROM on SPI2 bus

Tested on: Congo/Morocco/Kenya/Nigeria A1 BMC