### PR TITLE
I3c dummy data

### DIFF
--- a/drivers/i3c/master/mipi-i3c-hci/pio.c
+++ b/drivers/i3c/master/mipi-i3c-hci/pio.c
@@ -693,7 +693,8 @@ static bool hci_pio_process_resp(struct i3c_hci *hci, struct hci_pio_data *pio)
 				hci_pio_push_to_next_rx(hci, xfer, to_keep);
 			}
 			/* Workaround for A0 dummy data issue */
-			aspeed_dummy_data_work_around(hci, pio);
+			if (!aspeed_get_i3c_revision_id(hci))
+				aspeed_dummy_data_work_around(hci, pio);
 			/* then process the RX list pointer */
 			if (hci_pio_process_rx(hci, pio))
 				pio->enabled_irqs &= ~STAT_RX_THLD;

--- a/drivers/net/mctp/mctp-i3c.c
+++ b/drivers/net/mctp/mctp-i3c.c
@@ -305,12 +305,15 @@ static int mctp_i3c_probe(struct i3c_device *i3c)
 static void mctp_i3c_remove_device(struct mctp_i3c_device *mi)
 __must_hold(&busdevs_lock)
 {
+	int rc;
+
 	/* Ensure the tx thread isn't using the device */
 	mutex_lock(&mi->lock);
 
 	/* Counterpart of mctp_i3c_setup */
-	i3c_device_disable_ibi(mi->i3c);
-	i3c_device_free_ibi(mi->i3c);
+	rc = i3c_device_disable_ibi(mi->i3c);
+	if (!rc)
+		i3c_device_free_ibi(mi->i3c);
 
 	/* Counterpart of mctp_i3c_add_device */
 	i3cdev_set_drvdata(mi->i3c, NULL);


### PR DESCRIPTION
drivers: remove dummy data work around

Remove dummy data workaround which is needed only for A0. Free the IBI only when disable is successful to avoid the kernel traces.

tested: verified on Morocco