### PR TITLE
ARM64:dts:aspeed: Ghana DTS updated P1 SOFT FUSE

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -659,7 +659,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*56-63*/ "","","","","","","","",
 		/*64-71*/ "","","","","","","","",
 		/*72-79*/ "P1_MGMT_MON_POST_COMPLETE","","","","","","","",
-		/*80-87*/ "P1_MGMT_MON_PSP_SOFT_FUSE_NOTIFY","","P1_MGMT_MON_PWR_GOOD","","","","","",
+		/*80-87*/ "P1_MGMT_MON_PSP_SOFT_FUSE_NTFY","","P1_MGMT_MON_PWR_GOOD","","","","","",
 		/*88-95*/ "","","","","","","","P1_MGMT_ASSERT_WARM_RST_BTN_L",
 		/*96-103*/ "","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","",
 			"P1_MGMT_ASSERT_CLR_CMOS","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",


### PR DESCRIPTION
GPIO string names in DTS is 32 bytes (31 + NULL).
Renaming "P1_MGMT_MON_PSP_SOFT_FUSE_NOTIFY" to
"P1_MGMT_MON_PSP_SOFT_FUSE_NTFY"

Tested:
- verified in Morocco