### PR TITLE
clk: ast2700: Fix the condition for configuring the i3c clock

### DIFF
--- a/drivers/clk/clk-ast2700.c
+++ b/drivers/clk/clk-ast2700.c
@@ -1317,6 +1317,17 @@ static void ast2700_soc1_configure_mac01_clk(struct ast2700_clk_ctrl *clk_ctrl)
 	writel(reg[2], clk_ctrl->base + SCU1_MAC12_CLK_DLY_10M);
 }
 
+static void ast2700_soc1_configure_i3c_clk(struct ast2700_clk_ctrl *clk_ctrl)
+{
+	if (readl(clk_ctrl->base + SCU1_REVISION_ID) & REVISION_ID)
+		/* I3C 250MHz = HPLL/4 */
+		writel((readl(clk_ctrl->base + SCU1_CLK_SEL2) &
+			~SCU1_CLK_I3C_DIV_MASK) |
+			       FIELD_PREP(SCU1_CLK_I3C_DIV_MASK,
+					  SCU1_CLK_I3C_DIV(4)),
+		       clk_ctrl->base + SCU1_CLK_SEL2);
+}
+
 static int ast2700_soc_clk_probe(struct platform_device *pdev)
 {
 	struct ast2700_clk_data *clk_data;
@@ -1369,12 +1380,8 @@ static int ast2700_soc_clk_probe(struct platform_device *pdev)
 		}
 
 		ast2700_soc1_configure_mac01_clk(clk_ctrl);
+		ast2700_soc1_configure_i3c_clk(clk_ctrl);
 	}
-
-	/* I3C 250MHz = HPLL/4 */
-	writel((readl(clk_base + SCU1_CLK_SEL2) & ~SCU1_CLK_I3C_DIV_MASK) |
-		       FIELD_PREP(SCU1_CLK_I3C_DIV_MASK, SCU1_CLK_I3C_DIV(4)),
-	       clk_base + SCU1_CLK_SEL2);
 
 	for (i = 0; i < clk_data->nr_clks; i++) {
 		const struct ast2700_clk_info *clk = &clk_data->clk_info[i];


### PR DESCRIPTION
The i3c clock exists only in SCU1 and Ast2700A1.

Verified: Tested on Morocco

Change-Id: Ib47f0df787da72fd895b419315155bf25d14e10f