### PR TITLE
misc:amd-apml: handle DIMM Read Err in SBRMI

### DIFF
--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -126,7 +126,15 @@ static int sbrmi_read(struct device *dev, enum hwmon_sensor_types type,
 		msg.data_in.mb_in[RD_WR_DATA_INDEX] = (DIMM_BASE_ID + channel);
 		ret = rmi_mailbox_xfer(rmi_dev, &msg);
 		if (ret < 0)
-			return ret;
+		{
+			//TBD: Temporary work-around to avoid BMC hang in ipmid
+			//     Return 0 instead of the error
+			//     change the value to -1
+			pr_err("SBRMI_READ_DIMM_THERMAL_SENSOR failed with ret:%d, 0x%x, return value of -1\n", ret, (DIMM_BASE_ID + channel));
+			*val=-1;
+			ret=0;
+			// return ret;
+		}
 		break;
 
 	default:
@@ -141,9 +149,13 @@ static int sbrmi_read(struct device *dev, enum hwmon_sensor_types type,
 		}
 		else if (type == hwmon_temp)
 		{
+			//TBD: Temporary work-around to avoid BMC hang in ipmid
+			//     Return value of -1 in case of the DIMM Read error
+			if(*val != -1) {
 			// sbrmi temp is floating point, convert to deg C rational num
 			*val = (msg.data_out.mb_out[RD_WR_DATA_INDEX] >> DIMM_TEMP_OFFSET) * 1000;
 			*val = ((*val-32000) * (5/9));
+			}
 		}
 	}
 


### PR DESCRIPTION
IPMID will hang when SBRMI return read error for Reading DIMMs That will cause a BMC crash.
Temporary change SBRMI to return 0 in case of DIMM read error but return a value of -1 for the read.

tested:
- verified in Morocco