### PR TITLE
Keyboard and Mouse support for Node 1

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1251,6 +1251,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 };
 
+&uphy3b {
+	status = "okay";
+};
+
 &vhuba0 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_usb2ahpd0_default>;
@@ -1259,6 +1263,18 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 &usb3ahp {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+};
+
+&usb3bhp {
+	status = "okay";
+};
+
+&uphy2b {
+	status = "okay";
+};
+
+&vhubb1 {
+	status = "okay";
 };
 
 &xdma0 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1013,6 +1013,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 };
 
+&uphy3b {
+	status = "okay";
+};
+
 &vhuba0 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_usb2ahpd0_default>;
@@ -1021,6 +1025,18 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 &usb3ahp {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+};
+
+&usb3bhp {
+	status = "okay";
+};
+
+&uphy2b {
+	status = "okay";
+};
+
+&vhubb1 {
+	status = "okay";
 };
 
 &xdma0 {

--- a/drivers/phy/aspeed/aspeed-usb-phy3.c
+++ b/drivers/phy/aspeed/aspeed-usb-phy3.c
@@ -20,9 +20,9 @@
 #define PHY3P08_DEFAULT		0x5E406825	/* PHY PCS Protocol Setting #3 default value */
 #define PHY3P0C_DEFAULT		0x00000001	/* PHY PCS Protocol Setting #4 default value */
 
-#define DWC_CRTL_NUM	2
+#define DWC_CRTL_NUM	3
 
-#define USB_PHY3_INIT_DONE	BIT(15)	/* BIT15: USB3.1 Phy internal SRAM iniitalization done */
+#define USB_PHY3_INIT_DONE	BIT(15)	/* BIT15: USB3.1 Phy internal SRAM initialization done */
 #define USB_PHY3_SRAM_BYPASS	BIT(7)	/* USB3.1 Phy SRAM bypass */
 #define USB_PHY3_SRAM_EXT_LOAD	BIT(6)	/* USB3.1 Phy SRAM external load done */
 
@@ -52,6 +52,7 @@ struct aspeed_usb_phy3_model {
 };
 
 static struct usb_dwc3_ctrl ctrl_data[DWC_CRTL_NUM] = {
+	{0xc100, 0x00000006},	/* Set DWC3 GSBUSCFG0 for Bus Burst Type */
 	{0xc12c, 0x0c854802},	/* Set DWC3 GUCTL for ref_clk */
 	{0xc630, 0x0c800020},	/* Set DWC3 GLADJ for ref_clk */
 };


### PR DESCRIPTION
- Add fix from Aspeed for USB phy
- Enable USB devices for 2p systems on Node 1 partition

Tested: Verified on Morocco