### PR TITLE
ARM64:dts:aspeed Nigeria DTS changes for OOB PPR

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -52,6 +52,11 @@
 			no-map;
 		};
 
+		bmc_dev0_memory: bmc_dev0_memory@423800000 {
+			reg = <0x4 0x23800000 0x0 0x100000>;
+			no-map;
+		};
+
                 vbios_base0: vbios-base0@431bb0000 {
                         reg = <0x4 0x31bb0000 0x0 0x10000>;
                         no-map;
@@ -1036,4 +1041,9 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &jtag1 {
 	status = "okay";
+};
+
+&bmc_dev0 {
+	status = "okay";
+	memory-region = <&bmc_dev0_memory>;
 };


### PR DESCRIPTION
Add bmc_dev0 to Nigeria Device Tree to enable OOB PPR

Tested:
- Verified in Nigeria