### PR TITLE
ARM64:dts:aspeed PRB increase i3c speed

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -465,7 +465,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
@@ -505,7 +505,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p1_0: sbtsi@48,22400000001 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -558,7 +558,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -700,7 +700,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p0_0: sbtsi@4c,22400000001 {
@@ -740,7 +740,7 @@
 	status = "okay";
 	initial-role = "primary";
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
+	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 #ifdef VERONA
 	sbtsi_p1_0: sbtsi@48,22400000001 {


### PR DESCRIPTION
Increase PRB APML i3c speed from 10 MHz to 12.5 MHz (Max speed) Device tree was changed for:
- Kenya
- Nigeria
- Ghana

Tested:
- Verified in Kenya, Nigeria, Ghana