### PR TITLE
ARM64:dts:aspeed PRB Add fan cntl changes

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -228,8 +228,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			nct7363@20 {
-				compatible = "nuvoton,nct7363";
+				compatible = "nct,nct7363";
 				reg = <0x20>;
+				fan_sel_gpio = <3>;
 			};
 		};
 	};
@@ -366,8 +367,9 @@
 			#size-cells = <0>;
 
 			nct7363@20 {
-				compatible = "nuvoton,nct7363";
+				compatible = "nct,nct7363";
 				reg = <0x20>;
+				fan_sel_gpio = <3>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -269,12 +269,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			nct7363@20 {
-				compatible = "nuvoton,nct7363";
+				compatible = "nct,nct7363";
 				reg = <0x20>;
-			};
-			nct7363@21 {
-				compatible = "nuvoton,nct7363";
-				reg = <0x21>;
+				fan_sel_gpio = <3>;
 			};
 		};
 	};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -278,12 +278,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			nct7363@20 {
-				compatible = "nuvoton,nct7363";
+				compatible = "nct,nct7363";
 				reg = <0x20>;
-			};
-			nct7363@21 {
-				compatible = "nuvoton,nct7363";
-				reg = <0x21>;
+				fan_sel_gpio = <5>;
 			};
 		};
 	};
@@ -298,12 +295,9 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			nct7363@20 {
-				compatible = "nuvoton,nct7363";
+				compatible = "nct,nct7363";
 				reg = <0x20>;
-			};
-			nct7363@21 {
-				compatible = "nuvoton,nct7363";
-				reg = <0x21>;
+				fan_sel_gpio = <5>;
 			};
 		};
 	};


### PR DESCRIPTION
Change PRB device tree for the new Fan Cntl NCT7363 changes.
- Removed NCT7363 Cntl which is not in use
- Add fan_sel_gpio for the GPIO which gives the cntl of the fans to BMC 
- Device tree was changed for:
  - Kenya
  - Nigeria
  - Ghana

Tested:
- Verified in Kenya, Nigeria, Ghana