### PR TITLE
mctp pcie: do not free skb after calling netif_rx

### DIFF
--- a/drivers/net/mctp/mctp-pcie.c
+++ b/drivers/net/mctp/mctp-pcie.c
@@ -187,7 +187,6 @@ void mctp_pcie_netdev_rx(struct net_device *ndev,
 		ndev->stats.rx_bytes += MCTP_TRANSPORT_HDR_SIZE + psize;
 	} else {
 		ndev->stats.rx_dropped++;
-		kfree_skb(skb);
 	}
 }
 EXPORT_SYMBOL_GPL(mctp_pcie_netdev_rx);


### PR DESCRIPTION
When a driver calls netif_rx, it relinquishes ownership of the skb. The kernel then manages its lifecycle. Therefore, the driver should not free the skb after calling netif_rx.

tested: verified on Morocco