### PR TITLE
I3c mrl mwl

### DIFF
--- a/Documentation/devicetree/bindings/i3c/i3c.yaml
+++ b/Documentation/devicetree/bindings/i3c/i3c.yaml
@@ -140,6 +140,22 @@ patternProperties:
           through SETDASA. If static address is not present, this address is assigned
           through SETNEWDA after assigning a temporary address via ENTDAA.
 
+      mrl:
+        $ref: /schemas/types.yaml#/definitions/uint16
+        minimum: 0x10
+        maximum: 0xffff
+        description: |
+          Maximum Read Length(MRL) that the device supports. Used by the controller
+          to configure the transfer limits via SETMRL CCC.
+
+      mwl:
+        $ref: /schemas/types.yaml#/definitions/uint16
+        minimum: 0x10
+        maximum: 0xffff
+        description: |
+          Maximum Write Length(MWL) that the device supports. Used by the controller
+          to configure the max write limits via SETMWL CCC.
+
     required:
       - reg
 
@@ -183,5 +199,14 @@ examples:
         sensor@0,39200154004 {
             reg = <0x0 0x392 0x154004>;
             clocks = <&clock_provider 0>;
+        };
+
+        /*
+         * I3C device with configurable MRL/MWL buffers
+         */
+        target@0,22400002118 {
+            reg = <0x0 0x224 0x00002118>;
+            mrl = <69>;
+            mwl = <69>;
         };
     };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -874,6 +874,12 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_p0: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -513,6 +513,12 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_p0: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 &i3c5 {
@@ -522,6 +528,18 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_2x1p_p1: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
+
+	scoob_2p_p1: scoob@0,22401002118 {
+		reg = <0x0 0x224 0x01002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -564,6 +564,12 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_p0: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -914,6 +914,12 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_p0: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 /* P1-SEC */
@@ -951,6 +957,17 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_2x1p_p1: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
+	scoob_2p_p1: scoob@0,22401002118 {
+		reg = <0x0 0x224 0x01002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -713,6 +713,12 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_p0: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 &i3c5 {
@@ -722,6 +728,17 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	scoob_2x1p_p1: scoob@0,22400002118 {
+		reg = <0x0 0x224 0x00002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
+	scoob_2p_p1: scoob@0,22401002118 {
+		reg = <0x0 0x224 0x01002118>;
+		mrl = <69>;
+		mwl = <69>;
+	};
 };
 
 #ifdef I3C_HUB

--- a/drivers/i3c/master.c
+++ b/drivers/i3c/master.c
@@ -1786,9 +1786,29 @@ static int i3c_master_retrieve_dev_info(struct i3c_dev_desc *dev)
 		i3c_master_setmwl_locked(master, &dev->info, 128);
 	}
 
-	if (dev->boardinfo && dev->boardinfo->mrl)
+	if (dev->boardinfo && dev->boardinfo->mrl) {
+		/*
+		 * Broadcast DISEC issued in the beginning of the DAA process
+		 * failed leaving the SIR bit in the target devices set. This is
+		 * making the target devices ready to send the IBI as and when
+		 * the required conditions are met.
+		 *
+		 * MPIO triggers an IBI to send the MCTP discovery notify message
+		 * soon after it receives the SETMRL command.  An IBI for this target
+		 * is not expected until the BMC clears the REG_TARGET_IBI_REJECT bit
+		 * in the DAT for this device. If an IBI is received, without this bit
+		 * getting cleared, the Controller (in hardware) will send DISEC CCC
+		 * to the target asking it to disable the event generation.
+		 *
+		 * ENEC CCC is sent when the MCTP/I3C binding driver is probed/attached.
+		 * That time REG_TARGET_IBI_REJECT is cleared in the DAT table, and
+		 * ENEC CCC to the device is sent. From this point onwards, MPIO FW
+		 * can start sending the IBI.
+		 */
+		i3c_master_disec_locked(master, dev->info.dyn_addr, 1);
 		i3c_master_setmrl_locked(master, &dev->info,
 				dev->boardinfo->mrl, dev->info.max_ibi_len);
+	}
 
 	if (dev->boardinfo && dev->boardinfo->mwl)
 		i3c_master_setmwl_locked(master, &dev->info, dev->boardinfo->mwl);

--- a/drivers/i3c/master.c
+++ b/drivers/i3c/master.c
@@ -1714,6 +1714,27 @@ out:
 	return ret;
 }
 
+static void i3c_master_attach_boardinfo(struct i3c_dev_desc *i3cdev)
+{
+	struct i3c_master_controller *master = i3cdev->common.master;
+	struct i3c_dev_boardinfo *i3cboardinfo;
+	bool attach = false;
+
+	list_for_each_entry(i3cboardinfo, &master->boardinfo.i3c, node) {
+		if ((I3C_PID_MANUF_ID(i3cdev->info.pid) == 0x0 &&
+			i3cdev->info.pid == I3C_PID_RND_VAL(i3cboardinfo->pid)) ||
+			(i3cdev->info.pid == i3cboardinfo->pid)) {
+		    attach = true;
+		    break;
+		}
+	}
+
+	if (attach) {
+		i3cdev->boardinfo = i3cboardinfo;
+		i3cdev->info.static_addr = i3cboardinfo->static_addr;
+	}
+}
+
 static int i3c_master_retrieve_dev_info(struct i3c_dev_desc *dev)
 {
 	struct i3c_master_controller *master = i3c_dev_get_master(dev);
@@ -1747,6 +1768,8 @@ static int i3c_master_retrieve_dev_info(struct i3c_dev_desc *dev)
 			return ret;
 	}
 
+	i3c_master_attach_boardinfo(dev);
+
 	if (dev->info.bcr & I3C_BCR_IBI_PAYLOAD)
 		dev->info.max_ibi_len = 1;
 
@@ -1762,6 +1785,13 @@ static int i3c_master_retrieve_dev_info(struct i3c_dev_desc *dev)
 		i3c_master_setmrl_locked(master, &dev->info, 128, 128);
 		i3c_master_setmwl_locked(master, &dev->info, 128);
 	}
+
+	if (dev->boardinfo && dev->boardinfo->mrl)
+		i3c_master_setmrl_locked(master, &dev->info,
+				dev->boardinfo->mrl, dev->info.max_ibi_len);
+
+	if (dev->boardinfo && dev->boardinfo->mwl)
+		i3c_master_setmwl_locked(master, &dev->info, dev->boardinfo->mwl);
 
 	i3c_master_getmrl_locked(master, &dev->info);
 	i3c_master_getmwl_locked(master, &dev->info);
@@ -2434,21 +2464,6 @@ static void i3c_master_bus_cleanup(struct i3c_master_controller *master)
 	i3c_master_detach_free_devs(master);
 }
 
-static void i3c_master_attach_boardinfo(struct i3c_dev_desc *i3cdev)
-{
-	struct i3c_master_controller *master = i3cdev->common.master;
-	struct i3c_dev_boardinfo *i3cboardinfo;
-
-	list_for_each_entry(i3cboardinfo, &master->boardinfo.i3c, node) {
-		if (i3cdev->info.pid != i3cboardinfo->pid)
-			continue;
-
-		i3cdev->boardinfo = i3cboardinfo;
-		i3cdev->info.static_addr = i3cboardinfo->static_addr;
-		return;
-	}
-}
-
 static struct i3c_dev_desc *
 i3c_master_search_i3c_dev_duplicate(struct i3c_dev_desc *refdev)
 {
@@ -2505,8 +2520,6 @@ int i3c_master_add_i3c_dev_locked(struct i3c_master_controller *master,
 	ret = i3c_master_retrieve_dev_info(newdev);
 	if (ret)
 		goto err_detach_dev;
-
-	i3c_master_attach_boardinfo(newdev);
 
 	olddev = i3c_master_search_i3c_dev_duplicate(newdev);
 	if (olddev) {
@@ -2680,6 +2693,8 @@ of_i3c_master_add_i3c_boardinfo(struct i3c_master_controller *master,
 	u32 init_dyn_addr = 0;
 	u8 bcr = 0;
 	u8 dcr = 0;
+	u32 mrl = 0;
+	u32 mwl = 0;
 
 	boardinfo = devm_kzalloc(dev, sizeof(*boardinfo), GFP_KERNEL);
 	if (!boardinfo)
@@ -2722,6 +2737,12 @@ of_i3c_master_add_i3c_boardinfo(struct i3c_master_controller *master,
 
 	if (!of_property_read_u8(node, "bcr", &bcr))
 		boardinfo->bcr = bcr;
+
+	if (!of_property_read_u32(node, "mrl", &mrl))
+		boardinfo->mrl = (u16)mrl;
+
+	if (!of_property_read_u32(node, "mwl", &mwl))
+		boardinfo->mwl = (u16)mwl;
 
 	boardinfo->init_dyn_addr = init_dyn_addr;
 	boardinfo->of_node = of_node_get(node);

--- a/drivers/i3c/master/mipi-i3c-hci/core.c
+++ b/drivers/i3c/master/mipi-i3c-hci/core.c
@@ -488,9 +488,9 @@ static int i3c_hci_send_ccc_cmd(struct i3c_master_controller *m,
 	DECLARE_COMPLETION_ONSTACK(done);
 	int i, last, ret = 0;
 
-	dev_info(&hci->master.dev, "cmd=%#x rnw=%d dbp=%d db=%#x ndests=%d data[0].len=%d", ccc->id,
-	    ccc->rnw, ccc->dbp, ccc->db, ccc->ndests,
-	    ccc->dests[0].payload.len);
+	dev_info(&hci->master.dev, "tgt=%#x cmd=%#x rnw=%d dbp=%d db=%#x ndests=%d data[0].len=%d",
+		ccc->dests[0].addr, ccc->id, ccc->rnw, ccc->dbp, ccc->db,
+		ccc->ndests, ccc->dests[0].payload.len);
 
 	/*
 	 * Driver should be able to send the CCC commands on the i3c buses like the

--- a/include/linux/i3c/master.h
+++ b/include/linux/i3c/master.h
@@ -192,6 +192,8 @@ struct i3c_dev_boardinfo {
 	u64 pid;
 	u8 bcr;
 	u8 dcr;
+	u16 mrl;
+	u16 mwl;
 	struct device_node *of_node;
 };
 


### PR DESCRIPTION
Add support to configure the Max Read Length and Max Write Length for each i3c device using device tree tags.