### PR TITLE
ARM64:dts:aspeed: Ghana DTS updated Pump Fan Cntl

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -364,6 +364,14 @@
 			#size-cells = <0>;
 		};
 
+	};
+
+	i2cswitch@73 {
+		compatible = "nxp,pca9546";
+		reg = <0x73>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
 		fan_pump: i2c@2 {
 			reg = <2>;
 			#address-cells = <1>;


### PR DESCRIPTION
Pump Fans are located behind Mux 0x73 port 2.
Add Mux 0x73 Port 2 to Ghana DTS to access the pump fans.

tested:
- verified in Ghana