### PR TITLE
misc:amd-apml: report SBTSI Temp in C

### DIFF
--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -146,7 +146,9 @@ static int sbtsi_read(struct device *dev, enum hwmon_sensor_types type,
 	if (ret < 0)
 		return ret;
 
-	*val = sbtsi_reg_to_mc(temp_int, temp_dec);
+	//*val = sbtsi_reg_to_mc(temp_int, temp_dec);
+	// Report the Temp in C (rather than mC)
+	*val = temp_int;
 
 	return 0;
 }


### PR DESCRIPTION
SBTSI report the IOD temp in mC
Report the IOD Temp in C to be used directly by PID.

tested:
- verified in Morocco and Nigeria