### PR TITLE
ARM64:dts:aspeed: Update Ghana DTS

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -73,6 +73,13 @@
 			reusable;
 		};
 
+		video_engine_memory1: video1 {
+			size = <0x0 0x04000000>;  /* 64M */
+			alignment = <0x0 0x00010000>;
+			compatible = "shared-dma-pool";
+			reusable;
+		};
+
 		pcc_memory: pccbuffer {
 			reg = <0x4 0xE0000000 0x00001000>; /* 4K */
 			no-map;
@@ -82,6 +89,11 @@
 			size = <0x0 0x01000000>;
 			alignment = <0x0 0x01000000>;
 			compatible = "shared-dma-pool";
+			no-map;
+		};
+
+		espi0_mmbi_memory: espi0-mmbi-memory@424000000 {
+			reg = <0x4 0x24000000 0x0 0x4000000>;
 			no-map;
 		};
 	};
@@ -196,15 +208,23 @@
 	status = "okay";
 	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_spi2_cs1_default>;
 	pinctrl-names = "default";
-	compatible = "aspeed,ast2700-spi";
-
+	compatible = "aspeed,ast2700-spi-txrx";
 	flash@0 {
 		reg = <0>;
-		status = "okay";
+		status = "disabled";
 		m25p,fast-read;
 		label = "pnor";
 		compatible = "jedec,spi-nor";
 		spi-max-frequency = <16000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+	oled@0 {
+		reg = < 0 >; // Chip select 0
+		compatible = "ssd,ssd1322";
+		spi-max-frequency = <1000000>; // Adjust the frequency as needed
+		label = "ssd1322";
+		status = "okay"; // Enable the SSD1322 device
 		spi-tx-bus-width = <1>;
 		spi-rx-bus-width = <1>;
 	};
@@ -670,18 +690,19 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*24-31*/ "","","","","","","","P0_MGMT_ASSERT_NMI_BTN_L",
 		/*32-39*/ "","P0_MGMT_SOC_RESET_L","",
 			"MGMT_HDT_SEL","","SCM_JTAG_DBREQ","","JTAG_TRST_N",
-		/*40-47*/ "","P0_MGMT_ASSERT_WARM_RST_BTN_L","","","","","","",
-                /*48-55*/ "","","P1_MGMT_MON_THERMTRIP_L","P1_MGMT_ASSERT_THERMTRIP",
+		/*40-47*/ "","P0_MGMT_ASSERT_WARM_RST_BTN_L","P0_MGMT_MON_DIMM_AH_PCAMP",
+			"","P0_MGMT_MON_DIMM_IP_PCAMP","","P1_MGMT_MON_DIMM_AH_PCAMP","",
+		/*48-55*/ "P1_MGMT_MON_DIMM_IP_PCAMP","","P1_MGMT_MON_THERMTRIP_L","P1_MGMT_ASSERT_THERMTRIP",
 			"P1_MGMT_MON_PROCHOT_L","P1_MGMT_ASSERT_PROCHOT",
 			"P1_MGMT_MON_RSMRST_L","P1_ASSERT_RSMRST",
-		/*56-63*/ "","","","","","","","",
+		/*56-63*/ "","P1_MGMT_ASSERT_CLR_CMOS","MGMT_MON_HDT_CHAIN","MGMT_ASSERT_HDT_CHAIN","","","","",
 		/*64-71*/ "","","","","","","","",
 		/*72-79*/ "P1_MGMT_MON_POST_COMPLETE","","","","","","","",
 		/*80-87*/ "P1_MGMT_MON_PSP_SOFT_FUSE_NTFY","","P1_MGMT_MON_PWR_GOOD","","","","","",
-		/*88-95*/ "","","","","","","","P1_MGMT_ASSERT_WARM_RST_BTN_L",
-		/*96-103*/ "","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","",
-			"P1_MGMT_ASSERT_CLR_CMOS","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
-		/*104-111*/ "","","","","","HPM_STBY_EN","","",
+		/*88-95*/ "","","","","","","","",
+		/*96-103*/ "","","","","",
+			"","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
+		/*104-111*/ "P1_I3C_APML_ALERT_L","","","","","HPM_STBY_EN","","",
 		/*112-119*/ "","","","","","","","",
 		/*120-127*/ "","","","","","","","",
 		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",
@@ -694,7 +715,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*168-175*/ "","","","","","","","",
 		/*176-183*/ "","","","","","","","",
 		/*184-191*/ "","","","","","","","",
-		/*192-199*/ "","","","","","","","",
+		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","","",
 		/*200-207*/ "","","","","","","","",
 		/*208-215*/ "","","","","","","","",
 		/*216-223*/ "","","","","","","","";
@@ -705,13 +726,38 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	memory-region = <&video_engine_memory0>;
 };
 
+&video1 {
+	status = "okay";
+	memory-region = <&video_engine_memory1>;
+};
+
+/* eSPI node for P0 - PCC, eDAF enabled */
 &espi0 {
+   status = "okay";
+   perif-dma-mode;
+   perif-mmbi-enable;
+   perif-mmbi-src-addr = <0x0 0xa8000000>;
+   perif-mmbi-tgt-memory = <&espi0_mmbi_memory>;
+   perif-mmbi-instance-num = <0x1>;
+   perif-mcyc-enable;
+   perif-mcyc-src-addr = <0x0 0x98000000>;
+   perif-mcyc-size = <0x0 0x10000>;
+   oob-dma-mode;
+   flash-dma-mode;
+   flash-edaf-mode = <0>;
+   flash-edaf-tgt-addr = <0x1 0x80000000>;
+   flash-edaf-size = <0x0 0x2000000>;
+};
+
+/* eSPI node for P1 - PCC only */
+&espi1 {
 	status = "okay";
 	perif-dma-mode;
 	oob-dma-mode;
 	flash-dma-mode;
 };
 
+/* Post code capture for P0 */
 &lpc0_pcc {
 	port-addr = <0x80>;
 	dma-mode;
@@ -719,6 +765,19 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	rec-mode = <0x1>;
 	port-addr-hbits-select = <0x1>;
 	port-addr-xbits = <0x3>;
+	status = "okay";
+};
+
+/* Post code capture for P1 */
+&lpc1_pcc {
+	port-addr = <0x80>;
+	dma-mode;
+	A2600-15;
+	memory-region = <&pcc_memory>;
+	rec-mode = <0x1>;
+	port-addr-hbits-select = <0x1>;
+	port-addr-xbits = <0x3>;
+
 	status = "okay";
 };
 
@@ -756,6 +815,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 };
 
+&uphy3b {
+	status = "okay";
+};
+
 &vhuba0 {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_usb2ahpd0_default>;
@@ -764,6 +827,18 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 &usb3ahp {
 	status = "okay";
 	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+};
+
+&usb3bhp {
+	status = "okay";
+};
+
+&uphy2b {
+	status = "okay";
+};
+
+&vhubb1 {
+	status = "okay";
 };
 
 &xdma0 {


### PR DESCRIPTION
Change Ghana Device Tree based on Nigeria:
- update LTPI and add GPIOss for P1
- add video 1
- add espi0_mmbi_memory
- add LCD spi overlay
- Add espi1
- Add lpc1
- Add uphy3b
- Add usb3bhp
- Add uphy2b
- Add vhubb1

tested:
- verified in Ghana