### PR TITLE
i3c: Avoid returning on IBI disable failure

### DIFF
--- a/drivers/i3c/master.c
+++ b/drivers/i3c/master.c
@@ -3753,8 +3753,11 @@ int i3c_dev_disable_ibi_locked(struct i3c_dev_desc *dev)
 
 	master = i3c_dev_get_master(dev);
 	ret = master->ops->disable_ibi(dev);
-	if (ret)
-		return ret;
+	if (ret) {
+		dev_info(&master->dev,
+			"%s(): failed for device %d-%llx, ret = %d",
+			__func__, master->bus.id, dev->info.pid, ret);
+	}
 
 	reinit_completion(&dev->ibi->all_ibis_handled);
 	if (atomic_read(&dev->ibi->pending_ibis))


### PR DESCRIPTION
In i3c_dev_disable_ibi_locked(), the CCC command DISEC may fail if
the target device disappears before the IBI is disabled. Returning
on this failure leaves associated kernel worker threads dangling,
which can lead to resource leaks or system instability.

To address this, log the failure using dev_info() and continue with
the necessary cleanup as if the CCC command had succeeded. This
ensures robustness and avoids leaving threads in an inconsistent
state.

The log includes the bus ID and device PID to aid in debugging and
traceability.