### PR TITLE
remove IOD1 dts entry

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -890,11 +890,6 @@
 		assigned-address = <0x4c>;
 	};
 
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
 	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -580,11 +580,6 @@
 		assigned-address = <0x4c>;
 	};
 
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
 	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -930,11 +930,6 @@
 		assigned-address = <0x4c>;
 	};
 
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
 	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;
@@ -996,11 +991,6 @@
 	sbtsi_p1_iod0: sbtsi@48,22401000118 {
 		reg = <0x48 0x224 0x01000118>;
 		assigned-address = <0x48>;
-	};
-
-	sbtsi_p1_iod1: sbtsi@45,22401010118 {
-		reg = <0x45 0x224 0x01010118>;
-		assigned-address = <0x45>;
 	};
 
 	sbrmi_p1_iod0: sbrmi@38,22401011118 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -725,11 +725,6 @@
 		assigned-address = <0x4c>;
 	};
 
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
 	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;


### PR DESCRIPTION
Socket 0 IOD0 reports the maximum temperature of the socket to THM. Since IOD0 is sufficient for temperature reporting,
IOD1 is not required. The same applies for socket 1.
