### PR TITLE
Integ sp8 apml 2x1p pid map

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -873,38 +873,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p0_0: sbtsi@4c,22400000001 {
-		reg = <0x4c 0x224 0x00000001>;
-		assigned-address = <0x4c>;
-	};
-	sbrmi_p0_1: sbrmi@3c,22400000002 {
-		reg = <0x3c 0x224 0x00000002>;
-		assigned-address = <0x3c>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
-		reg = <0x4c 0x224 0x00000118>;
-		assigned-address = <0x4c>;
-	};
-
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
-	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
-		reg = <0x3c 0x224 0x00001118>;
-		assigned-address = <0x3c>;
-	};
-
-	scoob_p0: scoob@5c,22400002118 {
-		reg = <0x5c 0x224 0x00002118>;
-		assigned-address = <0x5c>;
-	};
-#endif
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -512,38 +512,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p0_0: sbtsi@4c,22400000001 {
-		reg = <0x4c 0x224 0x00000001>;
-		assigned-address = <0x4c>;
-	};
-	sbrmi_p0_1: sbrmi@3c,22400000002 {
-		reg = <0x3c 0x224 0x00000002>;
-		assigned-address = <0x3c>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
-		reg = <0x4c 0x224 0x00000118>;
-		assigned-address = <0x4c>;
-	};
-
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
-	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
-		reg = <0x3c 0x224 0x00001118>;
-		assigned-address = <0x3c>;
-	};
-
-	scoob_p0: scoob@5c,22400002118 {
-		reg = <0x5c 0x224 0x00002118>;
-		assigned-address = <0x5c>;
-	};
-#endif
 };
 
 &i3c5 {
@@ -552,38 +521,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p1_0: sbtsi@48,22400000001 {
-		reg = <0x48 0x224 0x00000001>;
-		assigned-address = <0x48>;
-	};
-	sbrmi_p1_1: sbrmi@38,22400000002 {
-		reg = <0x38 0x224 0x00000002>;
-		assigned-address = <0x38>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p1_iod0: sbtsi@48,22401000118 {
-		reg = <0x48 0x224 0x01000118>;
-		assigned-address = <0x48>;
-	};
-
-	sbtsi_p1_iod1: sbtsi@45,22401010118 {
-		reg = <0x45 0x224 0x01010118>;
-		assigned-address = <0x45>;
-	};
-
-	sbrmi_p1_iod0: sbrmi@38,22401011118 {
-		reg = <0x38 0x224 0x01011118>;
-		assigned-address = <0x38>;
-	};
-
-	scoob_p1: scoob@55,22401012118 {
-		reg = <0x55 0x224 0x01012118>;
-		assigned-address = <0x55>;
-	};
-#endif
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -563,38 +563,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p0_0: sbtsi@4c,22400000001 {
-		reg = <0x4c 0x224 0x00000001>;
-		assigned-address = <0x4c>;
-	};
-	sbrmi_p0_1: sbrmi@3c,22400000002 {
-		reg = <0x3c 0x224 0x00000002>;
-		assigned-address = <0x3c>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
-		reg = <0x4c 0x224 0x00000118>;
-		assigned-address = <0x4c>;
-	};
-
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
-	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
-		reg = <0x3c 0x224 0x00001118>;
-		assigned-address = <0x3c>;
-	};
-
-	scoob_p0: scoob@5c,22400002118 {
-		reg = <0x5c 0x224 0x00002118>;
-		assigned-address = <0x5c>;
-	};
-#endif
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -913,38 +913,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p0_0: sbtsi@4c,22400000001 {
-		reg = <0x4c 0x224 0x00000001>;
-		assigned-address = <0x4c>;
-	};
-	sbrmi_p0_1: sbrmi@3c,22400000002 {
-		reg = <0x3c 0x224 0x00000002>;
-		assigned-address = <0x3c>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
-		reg = <0x4c 0x224 0x00000118>;
-		assigned-address = <0x4c>;
-	};
-
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
-	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
-		reg = <0x3c 0x224 0x00001118>;
-		assigned-address = <0x3c>;
-	};
-
-	scoob_p0: scoob@5c,22400002118 {
-		reg = <0x5c 0x224 0x00002118>;
-		assigned-address = <0x5c>;
-	};
-#endif
 };
 
 /* P1-SEC */
@@ -981,38 +950,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p1_0: sbtsi@48,22400000001 {
-		reg = <0x48 0x224 0x00000001>;
-		assigned-address = <0x48>;
-	};
-	sbrmi_p1_1: sbrmi@38,22400000002 {
-		reg = <0x38 0x224 0x00000002>;
-		assigned-address = <0x38>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p1_iod0: sbtsi@48,22401000118 {
-		reg = <0x48 0x224 0x01000118>;
-		assigned-address = <0x48>;
-	};
-
-	sbtsi_p1_iod1: sbtsi@45,22401010118 {
-		reg = <0x45 0x224 0x01010118>;
-		assigned-address = <0x45>;
-	};
-
-	sbrmi_p1_iod0: sbrmi@38,22401011118 {
-		reg = <0x38 0x224 0x01011118>;
-		assigned-address = <0x38>;
-	};
-
-	scoob_p1: scoob@55,22401012118 {
-		reg = <0x55 0x224 0x01012118>;
-		assigned-address = <0x55>;
-	};
-#endif
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -708,38 +708,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p0_0: sbtsi@4c,22400000001 {
-		reg = <0x4c 0x224 0x00000001>;
-		assigned-address = <0x4c>;
-	};
-	sbrmi_p0_1: sbrmi@3c,22400000002 {
-		reg = <0x3c 0x224 0x00000002>;
-		assigned-address = <0x3c>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
-		reg = <0x4c 0x224 0x00000118>;
-		assigned-address = <0x4c>;
-	};
-
-	sbtsi_p0_iod1: sbtsi@44,22400010118 {
-		reg = <0x44 0x224 0x00010118>;
-		assigned-address = <0x44>;
-	};
-
-	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
-		reg = <0x3c 0x224 0x00001118>;
-		assigned-address = <0x3c>;
-	};
-
-	scoob_p0: scoob@5c,22400002118 {
-		reg = <0x5c 0x224 0x00002118>;
-		assigned-address = <0x5c>;
-	};
-#endif
 };
 
 &i3c5 {
@@ -748,38 +717,7 @@
 	internal-pullup = <2>;
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
-#ifdef VERONA
-	sbtsi_p1_0: sbtsi@48,22400000001 {
-		reg = <0x48 0x224 0x00000001>;
-		assigned-address = <0x48>;
-	};
-	sbrmi_p1_1: sbrmi@38,22400000002 {
-		reg = <0x38 0x224 0x00000002>;
-		assigned-address = <0x38>;
-	};
-#else
 	mctp-controller;
-
-	sbtsi_p1_iod0: sbtsi@48,22401000118 {
-		reg = <0x48 0x224 0x01000118>;
-		assigned-address = <0x48>;
-	};
-
-	sbtsi_p1_iod1: sbtsi@45,22401010118 {
-		reg = <0x45 0x224 0x01010118>;
-		assigned-address = <0x45>;
-	};
-
-	sbrmi_p1_iod0: sbrmi@38,22401011118 {
-		reg = <0x38 0x224 0x01011118>;
-		assigned-address = <0x38>;
-	};
-
-	scoob_p1: scoob@55,22401012118 {
-		reg = <0x55 0x224 0x01012118>;
-		assigned-address = <0x55>;
-	};
-#endif
 };
 
 #ifdef I3C_HUB

--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -431,6 +431,26 @@ static const char *sbtsi_addr_to_label(u8 addr)
 	}
 }
 
+static void map_sbtsi_pid_to_static_addr(struct i3c_device *i3cdev,
+			struct apml_sbtsi_device *tsi_dev)
+{
+	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x118))
+	{
+		tsi_dev->dev_static_addr = 0x4C;
+	}
+	else if ((i3cdev->bus->id == 5) &&
+			((i3cdev->desc->info.pid == 0x118) ||
+			(i3cdev->desc->info.pid == 0x01000118)))
+	{
+			tsi_dev->dev_static_addr = 0x48;
+	}
+	else
+	{
+		dev_err(&i3cdev->dev, "unknown pid. pid = 0x%llx\n",
+			i3cdev->desc->info.pid);
+	}
+}
+
 static int create_misc_tsi_device(struct apml_sbtsi_device *tsi_dev,
 				  struct device *dev)
 {
@@ -492,6 +512,13 @@ static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
 
 	/* Need to verify for the static address for i3cdev */
 	tsi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
+	map_sbtsi_pid_to_static_addr(i3cdev, tsi_dev);
+	if (tsi_dev->dev_static_addr == 0)
+	{
+		dev_err(dev, "SBTSI: PID = 0x%llx, static address zero, skip the device\n",
+				i3cdev->desc->info.pid);
+		return -ENXIO;
+	}
 
 	hwmon_dev_name = devm_kasprintf(dev, GFP_KERNEL, "sbtsi_%s",
 					sbtsi_addr_to_label(tsi_dev->dev_static_addr));

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -371,6 +371,26 @@ static const struct file_operations sbrmi_fops = {
 	.compat_ioctl	= sbrmi_ioctl,
 };
 
+static void map_sbrmi_pid_to_static_addr(struct i3c_device *i3cdev,
+					struct apml_sbrmi_device *rmi_dev)
+{
+	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x1118))
+	{
+		rmi_dev->dev_static_addr = 0x3C;
+	}
+	else if ((i3cdev->bus->id == 5) &&
+		((i3cdev->desc->info.pid == 0x1118) ||
+		(i3cdev->desc->info.pid == 0x01001118)))
+	{
+		rmi_dev->dev_static_addr = 0x38;
+	}
+	else
+	{
+		dev_err(&i3cdev->dev, "unknown pid. pid = 0x%llx\n",
+			i3cdev->desc->info.pid);
+	}
+}
+
 static int create_misc_rmi_device(struct apml_sbrmi_device *rmi_dev,
 				  struct device *dev)
 {
@@ -665,6 +685,12 @@ static int sbrmi_i3c_probe(struct i3c_device *i3cdev)
 
 	/* Need to verify for the static address for i3cdev */
 	rmi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
+	map_sbrmi_pid_to_static_addr(i3cdev, rmi_dev);
+	if (rmi_dev->dev_static_addr == 0)
+	{
+		dev_err(dev, "SBRMI: PID = 0x%llx, static address zero, skip the device\n",
+				i3cdev->desc->info.pid);
+	}
 
 	hwmon_dev_name = devm_kasprintf(dev, GFP_KERNEL, "sbrmi_%s",
 					sbrmi_addr_to_label(rmi_dev->dev_static_addr));


### PR DESCRIPTION
drivers: sbtsi: use static address mapped from PID

The current implementation creates device files based on I3C static
addresses. This patch changes the logic to map the PID to the device
static address and create the device file /dev/sbtsi-<static-id> file
for the APML library to communicate.

Also has the corresponding commits for device tree changes.

tested: verified on Morocco