### PR TITLE
boot:dts:aspeed: Update VR compatible strings for sp8

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
@@ -661,17 +661,17 @@
 
 			core0run@40 {
 				//P0_VDD_CORE_0_RUN
-				compatible = "raa229639";
+				compatible = "mps,mp2856";
 				reg = <0x40>;
 			};
 			core1run@41 {
 				//P0_VDD_CORE_1_RUN
-				compatible = "raa229639";
+				compatible = "mps,mp2856";
 				reg = <0x41>;
 			};
 			vddvddiorun@42 {
 				//P0_VDD_VDDIO_RUN
-				compatible = "raa229641";
+				compatible = "mps,mp2856";
 				reg = <0x42>;
 			};
 			vdd33s5run@46 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -597,17 +597,17 @@
 
 			p0core0run@40 {
 				//P0_VDD_CORE_0_RUN
-				compatible = "infineon,xdpe12284";
+				compatible = "raa229639";
 				reg = <0x40>;
 			};
 			p0core1run@41 {
 				//P0_VDD_CORE_1_RUN
-				compatible = "infineon,xdpe12284";
+				compatible = "raa229639";
 				reg = <0x41>;
 			};
 			p0vddvddiorun@42 {
 				//P0_VDD_VDDIO_RUN
-				compatible = "infineon,xdpe12284";
+				compatible = "raa229641";
 				reg = <0x42>;
 			};
 			p0vdd33s5run@46 {
@@ -873,17 +873,17 @@
 
 			p1core0run@40 {
 				//P0_VDD_CORE_0_RUN
-				compatible = "infineon,xdpe12284";
+				compatible = "raa229639";
 				reg = <0x40>;
 			};
 			p1core1run@41 {
 				//P0_VDD_CORE_1_RUN
-				compatible = "infineon,xdpe12284";
+				compatible = "raa229639";
 				reg = <0x41>;
 			};
 			p1vddvddiorun@42 {
 				//P0_VDD_VDDIO_RUN
-				compatible = "infineon,xdpe12284";
+				compatible = "raa229641";
 				reg = <0x42>;
 			};
 			p1vdd33s5run@46 {


### PR DESCRIPTION
   - Eagle: Replaced "raa229639"/"raa229641" with "mps,mp2856" for P0 VRs
   - Hornbill: Replaced "infineon,xdpe12284" with "raa229639"/"raa229641" for P0 and P1 VRs

Tested fields: Verified in Eagle and Hornbill platform.