### PR TITLE
arm64:dts:aspeed: KCS for node 2 and Change GPIO

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -671,7 +671,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*96-103*/ "","","","","",
 			"","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
 		/*104-111*/ "P1_I3C_APML_ALERT_L","","MGMT_MON_INTR_CHASSIS_L","","","HPM_STBY_EN","","",
-		/*112-119*/ "","","","","","","","",
+		/*112-119*/ "","P1_MGMT_SOC_RESET_L","","","","","","",
 		/*120-127*/ "","","","","","","","",
 		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",
 			"P0_MGMT_ASSERT_PWR_BTN_L","P1_MGMT_MON_RST_BTN_L","P1_MGMT_ASSERT_RST_BTN_L",
@@ -683,7 +683,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*168-175*/ "","","","","","","","",
 		/*176-183*/ "","","","","","","","",
 		/*184-191*/ "","","","","","","","",
-		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","","",
+		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","","","P1_MGMT_ASSERT_NMI_BTN_L","","",
 		/*200-207*/ "","","","","","","","",
 		/*208-215*/ "","","","","","","","",
 		/*216-223*/ "","","","","","","","";
@@ -818,6 +818,12 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <2>;
+};
+
+&lpc1_kcs3 {
+	status = "okay";
+	kcs-io-addr = <0xca4>;
+	kcs-channel = <4>;
 };
 
 &jtag1 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -1074,7 +1074,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*96-103*/ "","","","","",
 			"","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
 		/*104-111*/ "P1_I3C_APML_ALERT_L","","MGMT_MON_INTR_CHASSIS_L","","","HPM_STBY_EN","","",
-		/*112-119*/ "","","","","","","","",
+		/*112-119*/ "","P1_MGMT_SOC_RESET_L","","","","","","",
 		/*120-127*/ "","","","","","","","",
 		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",
 			"P0_MGMT_ASSERT_PWR_BTN_L","P1_MGMT_MON_RST_BTN_L","P1_MGMT_ASSERT_RST_BTN_L",
@@ -1086,7 +1086,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*168-175*/ "","","","","","","","",
 		/*176-183*/ "","","","","","","","",
 		/*184-191*/ "","","","","","","","",
-		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","","",
+		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","","","P1_MGMT_ASSERT_NMI_BTN_L","","",
 		/*200-207*/ "","","","","","","","",
 		/*208-215*/ "","","","","","","","",
 		/*216-223*/ "","","","","","","","";
@@ -1223,6 +1223,12 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <2>;
+};
+
+&lpc1_kcs3 {
+	status = "okay";
+	kcs-io-addr = <0xca4>;
+	kcs-channel = <4>;
 };
 
 &jtag1 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1092,7 +1092,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*96-103*/ "","","","","",
 			"","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
 		/*104-111*/ "P1_I3C_APML_ALERT_L","","MGMT_MON_INTR_CHASSIS_L","","","HPM_STBY_EN","","",
-		/*112-119*/ "","","","","","","","",
+		/*112-119*/ "","P1_MGMT_SOC_RESET_L","","","","","","",
 		/*120-127*/ "","","","","","","","",
 		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",
 			"P0_MGMT_ASSERT_PWR_BTN_L","P1_MGMT_MON_RST_BTN_L","P1_MGMT_ASSERT_RST_BTN_L",
@@ -1104,7 +1104,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*168-175*/ "","","","","","","","",
 		/*176-183*/ "","","","","","","","",
 		/*184-191*/ "","","","","","","","",
-		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","","",
+		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","","","P1_MGMT_ASSERT_NMI_BTN_L","","",
 		/*200-207*/ "","","","","","","","",
 		/*208-215*/ "","","","","","","","",
 		/*216-223*/ "","","","","","","","";
@@ -1241,6 +1241,12 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <2>;
+};
+
+&lpc1_kcs3 {
+	status = "okay";
+	kcs-io-addr = <0xca4>;
+	kcs-channel = <4>;
 };
 
 &jtag1 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -870,7 +870,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*96-103*/ "","","","","",
 			"","MGMT_MON_PLATFORM_CONFIG","MGMT_ASSERT_PLATFORM_CONFIG",
 		/*104-111*/ "P1_I3C_APML_ALERT_L","","MGMT_MON_INTR_CHASSIS_L","","","HPM_STBY_EN","","",
-		/*112-119*/ "","","","","","","","",
+		/*112-119*/ "","P1_MGMT_SOC_RESET_L","","","","","","",
 		/*120-127*/ "","","","","","","","",
 		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",
 			"P0_MGMT_ASSERT_PWR_BTN_L","P1_MGMT_MON_RST_BTN_L","P1_MGMT_ASSERT_RST_BTN_L",
@@ -882,7 +882,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*168-175*/ "","","","","","","","",
 		/*176-183*/ "","","","","","","","",
 		/*184-191*/ "","","","","","","","",
-		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","P1_MGMT_SOC_RESET_L","","P1_MGMT_ASSERT_NMI_BTN_L","","",
+		/*192-199*/ "","P1_MGMT_ASSERT_WARM_RST_BTN_L","","","","P1_MGMT_ASSERT_NMI_BTN_L","","",
 		/*200-207*/ "","","","","","","","",
 		/*208-215*/ "","","","","","","","",
 		/*216-223*/ "","","","","","","","";
@@ -1018,6 +1018,12 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <2>;
+};
+
+&lpc1_kcs3 {
+	status = "okay";
+	kcs-io-addr = <0xca4>;
+	kcs-channel = <4>;
 };
 
 &jtag1 {


### PR DESCRIPTION
- Add kcs channel for second node in 2P platforms
- Change gpio index for SOC_RESET

Tested:
- Verified in Morocco by Rajaganesh Rathinasabapathi