### PR TITLE
boot:dts:aspeed: Remove ltpi1 for SP8 Seagull

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -689,10 +689,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&ltpi1 {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;


### PR DESCRIPTION
Remove the 2nd LTPI for the 2nd FPGA (ltpi1) from SP8 PRB Seagull till FPGA is ready to be initialized.

Tested:
- verified in Seagull system.