### PR TITLE
drivers:soc:aspeed:lpc_pcc: DMA_DONE after copy

### DIFF
--- a/drivers/soc/aspeed/aspeed-lpc-pcc.c
+++ b/drivers/soc/aspeed/aspeed-lpc-pcc.c
@@ -178,8 +178,6 @@ static irqreturn_t aspeed_pcc_dma_isr(int irq, void *arg)
 	struct aspeed_pcc *pcc = (struct aspeed_pcc*)arg;
 	struct kfifo *fifo = &pcc->fifo;
 
-	regmap_write_bits(pcc->regmap, PCCR2, PCCR2_INT_STATUS_DMA_DONE, PCCR2_INT_STATUS_DMA_DONE);
-
 	regmap_read(pcc->regmap, PCCR6, &reg);
 	wptr = (reg & PCCR6_DMA_CUR_ADDR) - (pcc->dma.addr & PCCR6_DMA_CUR_ADDR);
 	rptr = pcc->dma.rptr;
@@ -194,6 +192,8 @@ static irqreturn_t aspeed_pcc_dma_isr(int irq, void *arg)
 	} while (rptr != wptr);
 
 	pcc->dma.rptr = rptr;
+
+	regmap_write_bits(pcc->regmap, PCCR2, PCCR2_INT_STATUS_DMA_DONE, PCCR2_INT_STATUS_DMA_DONE);
 
 	wake_up_interruptible(&pcc->wq);
 


### PR DESCRIPTION
- Updated aspeed_pcc_dma_isr() to move DMA_DONE after data copy.
- Ensure DMA_DONE interrupt status is cleared only after the DMA data has been copied to the FIFO. Previously, the status was updated before the copy, which could lead to race conditions or incomplete data handling.

Tested: Verified on morocco.