### PR TITLE
arm64: boot: dts revert mrl/mwl changes

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -874,12 +874,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_p0: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -513,12 +513,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_p0: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 &i3c5 {
@@ -528,18 +522,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_2x1p_p1: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
-
-	scoob_2p_p1: scoob@0,22401002118 {
-		reg = <0x0 0x224 0x01002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -564,12 +564,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_p0: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -914,12 +914,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_p0: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 /* P1-SEC */
@@ -957,17 +951,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_2x1p_p1: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
-	scoob_2p_p1: scoob@0,22401002118 {
-		reg = <0x0 0x224 0x01002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -713,12 +713,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_p0: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 &i3c5 {
@@ -728,17 +722,6 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
-
-	scoob_2x1p_p1: scoob@0,22400002118 {
-		reg = <0x0 0x224 0x00002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
-	scoob_2p_p1: scoob@0,22401002118 {
-		reg = <0x0 0x224 0x01002118>;
-		mrl = <69>;
-		mwl = <69>;
-	};
 };
 
 #ifdef I3C_HUB


### PR DESCRIPTION
Revert MRL, MWL changes from all the device tree fails because of not having the corresponding changes in the SoC firmware.

Upstream-Status: Inappropriate