### PR TITLE
arm64:dts:aspeed: KCS for node 2 and Change GPIO

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -822,7 +822,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -1227,7 +1227,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1245,7 +1245,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1022,7 +1022,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -828,7 +828,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 


### PR DESCRIPTION
- Fix kcs channel for second node in 2P platforms

Tested: Verified in Morocco