### PR TITLE
arm64:dts:aspeed: KCS for node 2

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -802,7 +802,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <2>;
 };
 
-&lpc1_kcs4 {
+&lpc1_kcs3 {
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -1225,7 +1225,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <2>;
 };
 
-&lpc1_kcs4 {
+&lpc1_kcs3 {
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1226,7 +1226,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <2>;
 };
 
-&lpc1_kcs4 {
+&lpc1_kcs3 {
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1003,7 +1003,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <2>;
 };
 
-&lpc1_kcs4 {
+&lpc1_kcs3 {
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -822,7 +822,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <2>;
 };
 
-&lpc1_kcs4 {
+&lpc1_kcs3 {
 	status = "okay";
 	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;


### PR DESCRIPTION
- Add kcs channel for second node in 2P platforms
- Change gpio index for SOC_RESET

Tested:
- Verified in Morocco