### PR TITLE
arm64:dts:aspeed: KCS for node 2

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -804,7 +804,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -1227,7 +1227,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1228,7 +1228,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1005,7 +1005,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -689,10 +689,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		/*216-223*/ "","","","","","","","";
 };
 
-&ltpi1 {
-	status = "okay";
-};
-
 &video0 {
 	status = "okay";
 	memory-region = <&video_engine_memory0>;
@@ -828,7 +824,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &lpc1_kcs3 {
 	status = "okay";
-	kcs-io-addr = <0xca4>;
+	kcs-io-addr = <0xca2>;
 	kcs-channel = <4>;
 };
 


### PR DESCRIPTION
- Add kcs channel for second node in 2P platforms
- Remove ltpi1 for SP8 Seagull

Tested:
- Verified in SP7 build