### PR TITLE
arch:boot:dts: enable chassis intrusion

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -1058,6 +1058,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <2>;
 };
 
+&chassis {
+    status = "disabled";
+};
+
 &jtag1 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -826,6 +826,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <4>;
 };
 
+&chassis {
+    status = "okay";
+};
+
 &jtag1 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -746,6 +746,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <2>;
 };
 
+&chassis {
+    status = "okay";
+};
+
 &jtag1 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1249,6 +1249,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <4>;
 };
 
+&chassis {
+    status = "disabled";
+};
+
 &jtag1 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1026,6 +1026,10 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	kcs-channel = <4>;
 };
 
+&chassis {
+    status = "okay";
+};
+
 &jtag1 {
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-g7-a0.dtsi
+++ b/arch/arm64/boot/dts/aspeed/aspeed-g7-a0.dtsi
@@ -1299,7 +1299,7 @@
 		};
 
 		chassis: chassis@14c04010 {
-			compatible = "aspeed,ast2600-chassis";
+			compatible = "aspeed,ast2700-chassis";
 			reg = <0 0x14c04010 0 0x4>;
 			interrupts-extended = <&intc0_5 5>;
 			status = "disabled";

--- a/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
+++ b/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
@@ -1471,7 +1471,7 @@
 		};
 
 		chassis: chassis@14c04010 {
-			compatible = "aspeed,ast2600-chassis";
+			compatible = "aspeed,ast2700-chassis";
 			reg = <0 0x14c04010 0 0x4>;
 			interrupts-extended = <&intc1_5 5>;
 			status = "disabled";


### PR DESCRIPTION
arch:boot:dts: enable chassis intrusion

This code enables/disables chassis intrusion on
all platforms depending on if they have the
necessary hardware for intrusion detection

Tested:
- Verified in SP7 build