### PR TITLE
RMI revision update to 0x31

### DIFF
--- a/drivers/misc/amd-apml/sbrmi-common.c
+++ b/drivers/misc/amd-apml/sbrmi-common.c
@@ -247,6 +247,7 @@ int rmi_mca_msr_read(struct apml_sbrmi_device *rmi_dev,
 
 		break;
 	case 0x21:
+	case 0x31:
 		ret = msr_datain_v21(rmi_dev, msg);
 		if (ret < 0)
 			goto exit_unlock;
@@ -359,6 +360,7 @@ int rmi_cpuid_read(struct apml_sbrmi_device *rmi_dev,
 			goto exit_unlock;
 		break;
 	case 0x21:
+	case 0x31:
 		ret = cpuid_datain_v21(rmi_dev, msg);
 		if (ret < 0)
 			goto exit_unlock;

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -461,7 +461,7 @@ static int sbrmi_i2c_identify_reg_addr_size(struct i2c_client *i2c, u32 *size, u
 		}
 	}
 
-	if (*rev == 0x21)
+	if (*rev == 0x21 || *rev == 0x31)
 		*size = SBRMI_REG_ADDR_SIZE_TWO_BYTE;
 	else
 		*size = SBRMI_REG_ADDR_SIZE_DEF;
@@ -584,7 +584,7 @@ static int sbrmi_i3c_identify_reg_addr_size(struct i3c_device *i3cdev, u32 *size
 
 	pr_err("sbrmi_i3c_identify_reg_addr_size(): *rev = 0x%x, *size = 0x%x\n",
 		*rev, *size);
-	if ((*rev & 0xff) == 0x21)
+	if ((*rev & 0xff) == 0x21 || (*rev & 0xff) == 0x31)
 		*size = SBRMI_REG_ADDR_SIZE_TWO_BYTE;
 	else
 		*size = SBRMI_REG_ADDR_SIZE_DEF;


### PR DESCRIPTION
- SBRMI revision helps in identifying the protocol to be used for CPUID and MCAMSR read.
- Additionally, revision helps in identifying the SBRMI register address size.