### PR TITLE
drivres:misc:amd-apml: New APML device ID for SP7 AB

### DIFF
--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -433,13 +433,17 @@ static const char *sbtsi_addr_to_label(u8 addr)
 static void map_sbtsi_pid_to_static_addr(struct i3c_device *i3cdev,
 			struct apml_sbtsi_device *tsi_dev)
 {
-	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x118))
+	if ((i3cdev->bus->id == 4) &&
+	   ((i3cdev->desc->info.pid == 0x118) ||
+	    (i3cdev->desc->info.pid == 0x22400000119)))
 	{
 		tsi_dev->dev_static_addr = 0x4C;
 	}
 	else if ((i3cdev->bus->id == 5) &&
-			((i3cdev->desc->info.pid == 0x118) ||
-			(i3cdev->desc->info.pid == 0x01000118)))
+		((i3cdev->desc->info.pid == 0x118) ||
+		 (i3cdev->desc->info.pid == 0x01000118) ||
+		 (i3cdev->desc->info.pid == 0x22400000119) ||
+		 (i3cdev->desc->info.pid == 0x22401000119)))
 	{
 			tsi_dev->dev_static_addr = 0x48;
 	}
@@ -625,6 +629,10 @@ static const struct i3c_device_id sbtsi_i3c_id[] = {
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x1, 0x118, NULL), /* Socket:0, IOD:1 */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x118, NULL), /* Socket:1 IOD:0 */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x101, 0x118, NULL), /* Socket:1 IOD:1 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x119, NULL), /* Socket:0, IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x1, 0x119, NULL), /* Socket:0, IOD:1 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x119, NULL), /* Socket:1 IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x101, 0x119, NULL), /* Socket:1 IOD:1 */
 	{}
 };
 MODULE_DEVICE_TABLE(i3c, sbtsi_i3c_id);

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -374,13 +374,17 @@ static const struct file_operations sbrmi_fops = {
 static void map_sbrmi_pid_to_static_addr(struct i3c_device *i3cdev,
 					struct apml_sbrmi_device *rmi_dev)
 {
-	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x1118))
+	if ((i3cdev->bus->id == 4) &&
+	   ((i3cdev->desc->info.pid == 0x1118) ||
+	    (i3cdev->desc->info.pid == 0x22400001119)))
 	{
 		rmi_dev->dev_static_addr = 0x3C;
 	}
 	else if ((i3cdev->bus->id == 5) &&
 		((i3cdev->desc->info.pid == 0x1118) ||
-		(i3cdev->desc->info.pid == 0x01001118)))
+		 (i3cdev->desc->info.pid == 0x01001118) ||
+		 (i3cdev->desc->info.pid == 0x22400001119) ||
+		 (i3cdev->desc->info.pid == 0x22401001119)))
 	{
 		rmi_dev->dev_static_addr = 0x38;
 	}
@@ -818,6 +822,8 @@ static const struct i3c_device_id sbrmi_i3c_id[] = {
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x2, NULL),
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x118, NULL), /* Socket:0, IOD:0 */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x118, NULL), /* Socket:1 IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x119, NULL), /* Socket:0, IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x119, NULL), /* Socket:1 IOD:0 */
 	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
 	{}
 };


### PR DESCRIPTION
Add new device IDs for SP7 AB APML devices
- 0x22400000119 for SBTSI
- 0x22400001119 for SBRMI

tested:
- verified in SP7 AB Congo