### PR TITLE
Integ sp8 dts overlay support 27012026

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -875,6 +875,16 @@
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
 
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
 	scoob_p0: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;
 		mrl = <69>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -565,6 +565,16 @@
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
 
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
 	scoob_p0: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;
 		mrl = <69>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -948,11 +948,27 @@
 		assigned-address = <0x4c>;
 	};
 
+<<<<<<< Updated upstream
+=======
+	sbtsi_p0_iod0_AB: sbtsi@4c,22400000119 {
+		reg = <0x4c 0x224 0x00000119>;
+		assigned-address = <0x4c>;
+	};
+
+>>>>>>> Stashed changes
 	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x3c>;
 	};
 
+<<<<<<< Updated upstream
+=======
+	sbrmi_p0_iod0_AB: sbrmi@3c,22400001119 {
+		reg = <0x3c 0x224 0x00001119>;
+		assigned-address = <0x3c>;
+	};
+
+>>>>>>> Stashed changes
 	scoob_p0: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;
 		mrl = <69>;
@@ -980,29 +996,66 @@
 		assigned-address = <0x48>;
 	};
 
+<<<<<<< Updated upstream
+=======
+	sbtsi_p1_iod0_AB: sbtsi@48,22401000119 {
+		status = "okay";
+		reg = <0x48 0x224 0x01000119>;
+		assigned-address = <0x48>;
+	};
+
+>>>>>>> Stashed changes
 	sbtsi_2x1p_iod0: sbtsi@4c,22400000118 {
 		status = "disabled";
 		reg = <0x4c 0x224 0x00000118>;
 		assigned-address = <0x48>;
 	};
 
+<<<<<<< Updated upstream
+=======
+	sbtsi_2x1p_iod0_AB: sbtsi@4c,22400000119 {
+		status = "disabled";
+		reg = <0x4c 0x224 0x00000119>;
+		assigned-address = <0x48>;
+	};
+
+>>>>>>> Stashed changes
 	sbrmi_p1_iod0: sbrmi@38,22401001118 {
 		status = "okay";
 		reg = <0x38 0x224 0x01001118>;
 		assigned-address = <0x38>;
 	};
 
+<<<<<<< Updated upstream
+=======
+	sbrmi_p1_iod0_AB: sbrmi@38,22401001119 {
+		status = "okay";
+		reg = <0x38 0x224 0x01001119>;
+		assigned-address = <0x38>;
+	};
+
+>>>>>>> Stashed changes
 	sbrmi_2x1p_iod0: sbrmi@3c,22400001118 {
 		status = "disabled";
 		reg = <0x3c 0x224 0x00001118>;
 		assigned-address = <0x38>;
 	};
 
+<<<<<<< Updated upstream
+=======
+	sbrmi_2x1p_iod0_AB: sbrmi@3c,22400001119 {
+		status = "disabled";
+		reg = <0x3c 0x224 0x00001119>;
+		assigned-address = <0x38>;
+	};
+#if 0
+>>>>>>> Stashed changes
 	scoob_2x1p_p1: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;
 		mrl = <69>;
 		mwl = <69>;
 	};
+
 	scoob_2p_p1: scoob@0,22401002118 {
 		reg = <0x0 0x224 0x01002118>;
 		mrl = <69>;
@@ -1019,6 +1072,10 @@
 		mrl = <69>;
 		mwl = <69>;
 	};
+<<<<<<< Updated upstream
+=======
+#endif
+>>>>>>> Stashed changes
 };
 
 #ifdef I3C_HUB

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -943,6 +943,16 @@
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
 
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
 	scoob_p0: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;
 		mrl = <69>;
@@ -963,6 +973,30 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	sbtsi_p1_iod0: sbtsi@48,22401000118 {
+		status = "okay";
+		reg = <0x48 0x224 0x01000118>;
+		assigned-address = <0x48>;
+	};
+
+	sbtsi_2x1p_iod0: sbtsi@4c,22400000118 {
+		status = "disabled";
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x48>;
+	};
+
+	sbrmi_p1_iod0: sbrmi@38,22401001118 {
+		status = "okay";
+		reg = <0x38 0x224 0x01001118>;
+		assigned-address = <0x38>;
+	};
+
+	sbrmi_2x1p_iod0: sbrmi@3c,22400001118 {
+		status = "disabled";
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x38>;
+	};
 
 	scoob_2x1p_p1: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -714,6 +714,16 @@
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
 
+	sbtsi_p0_iod0: sbtsi@4c,22400000118 {
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@3c,22400001118 {
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
 	scoob_p0: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;
 		mrl = <69>;
@@ -734,6 +744,30 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	sbtsi_p1_iod0: sbtsi@48,22401000118 {
+		status = "okay";
+		reg = <0x48 0x224 0x01000118>;
+		assigned-address = <0x48>;
+	};
+
+	sbtsi_2x1p_iod0: sbtsi@4c,22400000118 {
+		status = "disabled";
+		reg = <0x4c 0x224 0x00000118>;
+		assigned-address = <0x48>;
+	};
+
+	sbrmi_p1_iod0: sbrmi@38,22401001118 {
+		status = "okay";
+		reg = <0x38 0x224 0x01001118>;
+		assigned-address = <0x38>;
+	};
+
+	sbrmi_2x1p_iod0: sbrmi@3c,22400001118 {
+		status = "disabled";
+		reg = <0x3c 0x224 0x00001118>;
+		assigned-address = <0x38>;
+	};
 
 	scoob_2x1p_p1: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;

--- a/arch/arm64/boot/dts/aspeed/overlays/2x1p-config-overlay.dts
+++ b/arch/arm64/boot/dts/aspeed/overlays/2x1p-config-overlay.dts
@@ -12,9 +12,21 @@
 			assigned-address = <0x48>;
 			};
 
+			sbtsi_p1_iod0_AB: sbtsi@48,22401000119 {
+			status = "disabled";
+			reg = <0x48 0x224 0x01000119>;
+			assigned-address = <0x48>;
+			};
+
 			sbtsi_2x1p_iod0: sbtsi@4c,22400000118 {
 			status = "okay";
 			reg = <0x4c 0x224 0x00000118>;
+			assigned-address = <0x48>;
+			};
+
+			sbtsi_2x1p_iod0_AB: sbtsi@4c,22400000119 {
+			status = "okay";
+			reg = <0x4c 0x224 0x00000119>;
 			assigned-address = <0x48>;
 			};
 
@@ -24,9 +36,21 @@
 			assigned-address = <0x38>;
 			};
 
+			sbrmi_p1_iod0_AB: sbrmi@38,22401001119 {
+			status = "disabled";
+			reg = <0x38 0x224 0x01001119>;
+			assigned-address = <0x38>;
+			};
+
 			sbrmi_2x1p_iod0: sbrmi@3c,22400001118 {
 			status = "okay";
 			reg = <0x3c 0x224 0x00001118>;
+			assigned-address = <0x38>;
+			};
+
+			sbrmi_2x1p_iod0_AB: sbrmi@3c,22400001119 {
+			status = "okay";
+			reg = <0x3c 0x224 0x00001119>;
 			assigned-address = <0x38>;
 			};
 		};

--- a/arch/arm64/boot/dts/aspeed/overlays/2x1p-config-overlay.dts
+++ b/arch/arm64/boot/dts/aspeed/overlays/2x1p-config-overlay.dts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-2.0
+/dts-v1/;
+/plugin/;
+
+/ {
+	fragment@0 {
+		target-path = "/soc@14000000/i3c5@14c25000";
+		__overlay__ {
+			sbtsi_p1_iod0: sbtsi@48,22401000118 {
+			status = "disabled";
+			reg = <0x48 0x224 0x01000118>;
+			assigned-address = <0x48>;
+			};
+
+			sbtsi_2x1p_iod0: sbtsi@4c,22400000118 {
+			status = "okay";
+			reg = <0x4c 0x224 0x00000118>;
+			assigned-address = <0x48>;
+			};
+
+			sbrmi_p1_iod0: sbrmi@38,22401001118 {
+			status = "disabled";
+			reg = <0x38 0x224 0x01001118>;
+			assigned-address = <0x38>;
+			};
+
+			sbrmi_2x1p_iod0: sbrmi@3c,22400001118 {
+			status = "okay";
+			reg = <0x3c 0x224 0x00001118>;
+			assigned-address = <0x38>;
+			};
+		};
+	};
+};

--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -490,7 +490,7 @@ static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
 	mutex_init(&tsi_dev->lock);
 
 	/* Need to verify for the static address for i3cdev */
-	tsi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
+	tsi_dev->dev_static_addr = i3cdev->desc->info.dyn_addr;
 
 	hwmon_dev_name = devm_kasprintf(dev, GFP_KERNEL, "sbtsi_%s",
 					sbtsi_addr_to_label(tsi_dev->dev_static_addr));

--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -433,17 +433,13 @@ static const char *sbtsi_addr_to_label(u8 addr)
 static void map_sbtsi_pid_to_static_addr(struct i3c_device *i3cdev,
 			struct apml_sbtsi_device *tsi_dev)
 {
-	if ((i3cdev->bus->id == 4) &&
-	   ((i3cdev->desc->info.pid == 0x118) ||
-	    (i3cdev->desc->info.pid == 0x22400000119)))
+	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x118))
 	{
 		tsi_dev->dev_static_addr = 0x4C;
 	}
 	else if ((i3cdev->bus->id == 5) &&
-		((i3cdev->desc->info.pid == 0x118) ||
-		 (i3cdev->desc->info.pid == 0x01000118) ||
-		 (i3cdev->desc->info.pid == 0x22400000119) ||
-		 (i3cdev->desc->info.pid == 0x22401000119)))
+			((i3cdev->desc->info.pid == 0x118) ||
+			(i3cdev->desc->info.pid == 0x01000118)))
 	{
 			tsi_dev->dev_static_addr = 0x48;
 	}

--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -430,26 +430,6 @@ static const char *sbtsi_addr_to_label(u8 addr)
 	}
 }
 
-static void map_sbtsi_pid_to_static_addr(struct i3c_device *i3cdev,
-			struct apml_sbtsi_device *tsi_dev)
-{
-	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x118))
-	{
-		tsi_dev->dev_static_addr = 0x4C;
-	}
-	else if ((i3cdev->bus->id == 5) &&
-			((i3cdev->desc->info.pid == 0x118) ||
-			(i3cdev->desc->info.pid == 0x01000118)))
-	{
-			tsi_dev->dev_static_addr = 0x48;
-	}
-	else
-	{
-		dev_err(&i3cdev->dev, "unknown pid. pid = 0x%llx\n",
-			i3cdev->desc->info.pid);
-	}
-}
-
 static int create_misc_tsi_device(struct apml_sbtsi_device *tsi_dev,
 				  struct device *dev)
 {
@@ -511,13 +491,6 @@ static int sbtsi_i3c_probe(struct i3c_device *i3cdev)
 
 	/* Need to verify for the static address for i3cdev */
 	tsi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
-	map_sbtsi_pid_to_static_addr(i3cdev, tsi_dev);
-	if (tsi_dev->dev_static_addr == 0)
-	{
-		dev_err(dev, "SBTSI: PID = 0x%llx, static address zero, skip the device\n",
-				i3cdev->desc->info.pid);
-		return -ENXIO;
-	}
 
 	hwmon_dev_name = devm_kasprintf(dev, GFP_KERNEL, "sbtsi_%s",
 					sbtsi_addr_to_label(tsi_dev->dev_static_addr));

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -664,7 +664,7 @@ static int sbrmi_i3c_probe(struct i3c_device *i3cdev)
 	dev_set_drvdata(dev, (void *)rmi_dev);
 
 	/* Need to verify for the static address for i3cdev */
-	rmi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
+	rmi_dev->dev_static_addr = i3cdev->desc->info.dyn_addr;
 
 	hwmon_dev_name = devm_kasprintf(dev, GFP_KERNEL, "sbrmi_%s",
 					sbrmi_addr_to_label(rmi_dev->dev_static_addr));

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -374,17 +374,13 @@ static const struct file_operations sbrmi_fops = {
 static void map_sbrmi_pid_to_static_addr(struct i3c_device *i3cdev,
 					struct apml_sbrmi_device *rmi_dev)
 {
-	if ((i3cdev->bus->id == 4) &&
-	   ((i3cdev->desc->info.pid == 0x1118) ||
-	    (i3cdev->desc->info.pid == 0x22400001119)))
+	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x1118))
 	{
 		rmi_dev->dev_static_addr = 0x3C;
 	}
 	else if ((i3cdev->bus->id == 5) &&
 		((i3cdev->desc->info.pid == 0x1118) ||
-		 (i3cdev->desc->info.pid == 0x01001118) ||
-		 (i3cdev->desc->info.pid == 0x22400001119) ||
-		 (i3cdev->desc->info.pid == 0x22401001119)))
+		(i3cdev->desc->info.pid == 0x01001118)))
 	{
 		rmi_dev->dev_static_addr = 0x38;
 	}

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -371,26 +371,6 @@ static const struct file_operations sbrmi_fops = {
 	.compat_ioctl	= sbrmi_ioctl,
 };
 
-static void map_sbrmi_pid_to_static_addr(struct i3c_device *i3cdev,
-					struct apml_sbrmi_device *rmi_dev)
-{
-	if ((i3cdev->bus->id == 4) && (i3cdev->desc->info.pid == 0x1118))
-	{
-		rmi_dev->dev_static_addr = 0x3C;
-	}
-	else if ((i3cdev->bus->id == 5) &&
-		((i3cdev->desc->info.pid == 0x1118) ||
-		(i3cdev->desc->info.pid == 0x01001118)))
-	{
-		rmi_dev->dev_static_addr = 0x38;
-	}
-	else
-	{
-		dev_err(&i3cdev->dev, "unknown pid. pid = 0x%llx\n",
-			i3cdev->desc->info.pid);
-	}
-}
-
 static int create_misc_rmi_device(struct apml_sbrmi_device *rmi_dev,
 				  struct device *dev)
 {
@@ -685,12 +665,6 @@ static int sbrmi_i3c_probe(struct i3c_device *i3cdev)
 
 	/* Need to verify for the static address for i3cdev */
 	rmi_dev->dev_static_addr = i3cdev->desc->info.static_addr;
-	map_sbrmi_pid_to_static_addr(i3cdev, rmi_dev);
-	if (rmi_dev->dev_static_addr == 0)
-	{
-		dev_err(dev, "SBRMI: PID = 0x%llx, static address zero, skip the device\n",
-				i3cdev->desc->info.pid);
-	}
 
 	hwmon_dev_name = devm_kasprintf(dev, GFP_KERNEL, "sbrmi_%s",
 					sbrmi_addr_to_label(rmi_dev->dev_static_addr));


### PR DESCRIPTION
Add support for the dts overlay in linux-aspeed for Venice A0.
This patch requires OpenBMC changes as pushed to gerrit:  http://gerrit-git.amd.com/c/ESE/ec/BMC/openbmc/+/1304793

Testing is not done on AB platform as do not have access to platform.
Testing report and patch is shared before for A0 platforms.