### PR TITLE
arm64:dts:aspeed: Initial SP8 1P VRs

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
@@ -315,26 +315,28 @@
 
 			core0run@40 {
 				//P0_VDD_CORE_0_RUN
-				compatible = "mps,mp2856";
+				compatible = "mps,mp2869";
 				reg = <0x40>;
 			};
 			core1run@41 {
 				//P0_VDD_CORE_1_RUN
-				compatible = "mps,mp2856";
+				compatible = "mps,mp2869";
 				reg = <0x41>;
 			};
 			vddvddiorun@42 {
 				//P0_VDD_VDDIO_RUN
-				compatible = "mps,mp2856";
+				compatible = "mps,mp29608";
 				reg = <0x42>;
 			};
 			vdd33s5run@46 {
 				//P0_VDD_33_S5_RUN
+				// Infineon TDA38725
 				compatible = "pmbus";
 				reg = <0x46>;
 			};
 			vdd18s5run@47 {
 				//P0_VDD_18_S5_RUN
+				// Infineon TDA38740
 				compatible = "pmbus";
 				reg = <0x47>;
 			};
@@ -361,16 +363,19 @@
 
 			vdd33dual@43 {
 				//VDD_33_DUAL VRM
+				// Infineon TDA38725
 				compatible = "pmbus";
 				reg = <0x43>;
 			};
 			vdd33run@45 {
 				//VDD_33_RUN VRM
+				// Infineon TDA38725
 				compatible = "pmbus";
 				reg = <0x45>;
 			};
 			vdd5dual@48 {
 				//VDD_5_DUAL VRM
+				// Infineon TDA38725
 				compatible = "pmbus";
 				reg = <0x48>;
 			};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
@@ -315,27 +315,29 @@
 			#size-cells = <0>;
 
 			core0run@40 {
-				//P0_VDD_CORE_0_RUN
-				compatible = "mps,mp2856";
+				// P0_VDD_CORE_0_RUN
+				compatible = "mps,mp2869";
 				reg = <0x40>;
 			};
 			core1run@41 {
-				//P0_VDD_CORE_1_RUN
-				compatible = "mps,mp2856";
+				// P0_VDD_CORE_1_RUN
+				compatible = "mps,mp2869";
 				reg = <0x41>;
 			};
 			vddvddiorun@42 {
-				//P0_VDD_VDDIO_RUN
-				compatible = "mps,mp2856";
+				// P0_VDD_IO_RUN
+				compatible = "mps,mp29608";
 				reg = <0x42>;
 			};
 			vdd33s5run@47 {
-				//P0_VDD_33_S5_RUN
+				// P0_VDD_18_S5_RUN
+				// Infineon: TDA38740A
 				compatible = "pmbus";
 				reg = <0x47>;
 			};
 			vdd18s5run@08 {
-				//P0_VDD_18_S5_RUN
+				// P0_VDD_33_S5_RUN
+				// TDK:FS1604
 				compatible = "pmbus";
 				reg = <0x47>;
 			};
@@ -361,20 +363,29 @@
 			#size-cells = <0>;
 
 			vdd33dual@43 {
-				//VDD_33_DUAL VRM
+				// 47 in EVT2
+				// P3V3_AUX
+				// Infineon: TDA38725A
 				compatible = "pmbus";
 				reg = <0x43>;
 			};
 			p2v5_aux@8{
-				compatible = "ism,ism6636c";
+				// 0B in EVT2
+				// P5V_S5
+				// TDK:FS1006
+				compatible = "pmbus";
 				reg = <0x8>;
 			};
 			p1v8_aux@9{
-				compatible = "ism,ism6636c";
+				// P1V8_AUX
+				// TDK:FS1606
+				compatible = "pmbus";
 				reg = <0x9>;
 			};
 			p1v0_aux@a{
-				compatible = "ism,ism6636c";
+				// P0V85_AUX
+				// TDK:FS1606
+				compatible = "pmbus";
 				reg = <0xa>;
 			};
 		};


### PR DESCRIPTION
Change Device Trees for new EVT2 Falcon and RevA Eagle  VR devices
- corrected VR devices for MP28xx
- change Infineon:TDA38xx to pmbus for testing
- Change TDK:FS16xx to pmbus for testing

tested:
- verified in SP8 Falcon and RevA Eagle