### PR TITLE
drivres:misc:amd-apml: New APML device ID for SP8

### DIFF
--- a/drivers/misc/amd-apml/apml_sbtsi.c
+++ b/drivers/misc/amd-apml/apml_sbtsi.c
@@ -435,7 +435,8 @@ static void map_sbtsi_pid_to_static_addr(struct i3c_device *i3cdev,
 {
 	if ((i3cdev->bus->id == 4) &&
 	   ((i3cdev->desc->info.pid == 0x118) ||
-	    (i3cdev->desc->info.pid == 0x22400000119)))
+	    (i3cdev->desc->info.pid == 0x22400000119) ||
+	    (i3cdev->desc->info.pid == 0x2240000011A)))
 	{
 		tsi_dev->dev_static_addr = 0x4C;
 	}
@@ -443,7 +444,9 @@ static void map_sbtsi_pid_to_static_addr(struct i3c_device *i3cdev,
 		((i3cdev->desc->info.pid == 0x118) ||
 		 (i3cdev->desc->info.pid == 0x01000118) ||
 		 (i3cdev->desc->info.pid == 0x22400000119) ||
-		 (i3cdev->desc->info.pid == 0x22401000119)))
+		 (i3cdev->desc->info.pid == 0x22401000119) ||
+		 (i3cdev->desc->info.pid == 0x2240000011A) ||
+		 (i3cdev->desc->info.pid == 0x2240100011A)))
 	{
 			tsi_dev->dev_static_addr = 0x48;
 	}
@@ -633,6 +636,10 @@ static const struct i3c_device_id sbtsi_i3c_id[] = {
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x1, 0x119, NULL), /* Socket:0, IOD:1 */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x119, NULL), /* Socket:1 IOD:0 */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x101, 0x119, NULL), /* Socket:1 IOD:1 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x11A, NULL), /* SP8 Socket:0, IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x1, 0x11A, NULL), /* SP8 Socket:0, IOD:1 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x11A, NULL), /* SP8 Socket:1 IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x101, 0x11A, NULL), /* SP8 Socket:1 IOD:1 */
 	{}
 };
 MODULE_DEVICE_TABLE(i3c, sbtsi_i3c_id);

--- a/drivers/misc/amd-apml/sbrmi.c
+++ b/drivers/misc/amd-apml/sbrmi.c
@@ -376,7 +376,8 @@ static void map_sbrmi_pid_to_static_addr(struct i3c_device *i3cdev,
 {
 	if ((i3cdev->bus->id == 4) &&
 	   ((i3cdev->desc->info.pid == 0x1118) ||
-	    (i3cdev->desc->info.pid == 0x22400001119)))
+	    (i3cdev->desc->info.pid == 0x22400001119) ||
+	    (i3cdev->desc->info.pid == 0x2240000111A)))
 	{
 		rmi_dev->dev_static_addr = 0x3C;
 	}
@@ -384,7 +385,9 @@ static void map_sbrmi_pid_to_static_addr(struct i3c_device *i3cdev,
 		((i3cdev->desc->info.pid == 0x1118) ||
 		 (i3cdev->desc->info.pid == 0x01001118) ||
 		 (i3cdev->desc->info.pid == 0x22400001119) ||
-		 (i3cdev->desc->info.pid == 0x22401001119)))
+		 (i3cdev->desc->info.pid == 0x22401001119) ||
+		 (i3cdev->desc->info.pid == 0x2240000111A) ||
+		 (i3cdev->desc->info.pid == 0x2240100111A)))
 	{
 		rmi_dev->dev_static_addr = 0x38;
 	}
@@ -824,6 +827,8 @@ static const struct i3c_device_id sbrmi_i3c_id[] = {
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x118, NULL), /* Socket:1 IOD:0 */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x119, NULL), /* Socket:0, IOD:0 */
 	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x119, NULL), /* Socket:1 IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x0, 0x11A, NULL), /* SP8 Socket:0, IOD:0 */
+	I3C_DEVICE_EXTRA_INFO(0x112, 0x100, 0x11A, NULL), /* Socket:1 IOD:0 */
 	I3C_DEVICE_EXTRA_INFO(0, 0x0, 0x0, NULL),
 	{}
 };


### PR DESCRIPTION
Add new device IDs for SP8 APML devices
- 0x2240000011A for SBTSI
- 0x2240000111A for SBRMI

tested:
- verified in SP7