### PR TITLE
arm:dts: i2c10 clk-freq and video memory increase

### DIFF
--- a/arch/arm/boot/dts/aspeed/aspeed-g6.dtsi
+++ b/arch/arm/boot/dts/aspeed/aspeed-g6.dtsi
@@ -1086,7 +1086,7 @@
 		clocks = <&syscon ASPEED_CLK_APB2>;
 		resets = <&syscon ASPEED_RESET_I2C>;
 		interrupts = <GIC_SPI 120 IRQ_TYPE_LEVEL_HIGH>;
-		bus-frequency = <100000>;
+		bus-frequency = <400000>;
 		pinctrl-names = "default";
 		pinctrl-0 = <&pinctrl_i2c11_default>;
 		status = "disabled";

--- a/arch/arm/boot/dts/aspeed/ast2600-amd-bmc-common.dtsi
+++ b/arch/arm/boot/dts/aspeed/ast2600-amd-bmc-common.dtsi
@@ -43,7 +43,7 @@
 		ranges;
 
 		video_engine_memory: jpegbuffer {
-			size = <0x02000000>;	/* 32M */
+			size = <0x04000000>;	/* 64M */
 			alignment = <0x01000000>;
 			compatible = "shared-dma-pool";
 			reusable;


### PR DESCRIPTION
- updated i2c10 clk freq to 400kHz
- updated the video engine buffer memory to 64MB from 32MB because KVM crashing (congo uses 64MB as well)

Verifed: Tested on chalupa