### PR TITLE
arm:dts: i2c10 clk-freq and video memory increase

### DIFF
--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
@@ -532,7 +532,8 @@
 &i2c10 {
 	// Net name i2c7 (SCM_I2C7)
 	status = "okay";
-    multi-master;
+	bus-frequency = <400000>;
+	multi-master;
 	mctp-controller;
 	mctp@10 {
 		compatible = "mctp-i2c-controller";

--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
@@ -260,7 +260,8 @@
 &i2c10 {
 	// Net name i2c7
 	status = "okay";
-  multi-master;
+	bus-frequency = <400000>;
+	multi-master;
 	mctp-controller;
 	mctp@10 {
 		compatible = "mctp-i2c-controller";

--- a/arch/arm/boot/dts/aspeed/ast2600-amd-bmc-common.dtsi
+++ b/arch/arm/boot/dts/aspeed/ast2600-amd-bmc-common.dtsi
@@ -43,7 +43,7 @@
 		ranges;
 
 		video_engine_memory: jpegbuffer {
-			size = <0x02000000>;	/* 32M */
+			size = <0x04000000>;	/* 64M */
 			alignment = <0x01000000>;
 			compatible = "shared-dma-pool";
 			reusable;


### PR DESCRIPTION
- updated i2c10 clk freq to 400kHz
- updated the video engine buffer memory to 64MB from 32MB because KVM crashing (congo uses 64MB as well)

Verified: Tested on chalupa