### PR TITLE
arm:dts: i2c10 clk revert to 100k

### DIFF
--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
@@ -532,7 +532,6 @@
 &i2c10 {
 	// Net name i2c7 (SCM_I2C7)
 	status = "okay";
-	bus-frequency = <400000>;
 	multi-master;
 	mctp-controller;
 	mctp@10 {

--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
@@ -260,7 +260,6 @@
 &i2c10 {
 	// Net name i2c7
 	status = "okay";
-	bus-frequency = <400000>;
 	multi-master;
 	mctp-controller;
 	mctp@10 {


### PR DESCRIPTION
- reverting to 100k from 400k
- Hitting issue with 400k clk for response of activatefirmware for pldm fw-update

Verified : Tested on Chalupa