### PR TITLE
arm:dts:aspeed update video mem to 64M for galena

### DIFF
--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
@@ -50,7 +50,7 @@
 		ranges;
 
 		video_engine_memory: jpegbuffer {
-			size = <0x02000000>;	/* 32M */
+			size = <0x04000000>;	/* 64M */
 			alignment = <0x01000000>;
 			compatible = "shared-dma-pool";
 			reusable;


### PR DESCRIPTION
- Hitting kvm disconnection.
- Update to 64M from 32M, resolved issue (simlar to Chalupa/Congo)

Verified: Tested on galena