### PR TITLE
arm:dts: Remove qspi from pinctrl for bios MI350P

### DIFF
--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
@@ -68,7 +68,7 @@
 &spi1 {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_qspi1_default>;
+	pinctrl-0 = <&pinctrl_spi1_default>;
 	fmc-spi-user-mode;
 	compatible = "aspeed,ast2600-spi";
 
@@ -83,7 +83,7 @@
 &spi2 {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_qspi2_default>;
+	pinctrl-0 = <&pinctrl_spi2_default>;
 	fmc-spi-user-mode;
 	compatible = "aspeed,ast2600-spi";
 

--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
@@ -113,7 +113,7 @@
 &spi1 {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_qspi1_default>;
+	pinctrl-0 = <&pinctrl_spi1_default>;
 	fmc-spi-user-mode;
 	compatible = "aspeed,ast2600-spi";
 
@@ -128,7 +128,7 @@
 &spi2 {
 	status = "okay";
 	pinctrl-names = "default";
-	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_qspi2_default>;
+	pinctrl-0 = <&pinctrl_spi2_default>;
 	fmc-spi-user-mode;
 	compatible = "aspeed,ast2600-spi";
 


### PR DESCRIPTION
- On the integ_sp7_new branch, we have a new spi-smc driver.
- qspi pinctrl entry causing pin claim/freeing error.
- Venice boards dts (congo, morocco) don't have qspi_pinctrl for bios.

Verified: Tested on Chalupa and Galena