### PR TITLE
amd:dts: Add Chassis HWMON to SP7 PRBs

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -876,3 +876,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	non-removable;
 	max-frequency = <200000000>;
 };
+
+&chassis {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -788,3 +788,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	non-removable;
 	max-frequency = <200000000>;
 };
+
+&chassis {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1094,3 +1094,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	non-removable;
 	max-frequency = <200000000>;
 };
+
+&chassis {
+	status = "okay";
+};


### PR DESCRIPTION
Add Aspeed chassis HWMON driver for SP7 PRB platforms to detect Chassis Intrusion.

Tested:
- verified in SP7 Kenya