### PR TITLE
driver:hwmon: change Aspeed Chassis back to original

### DIFF
--- a/drivers/hwmon/aspeed-chassis.c
+++ b/drivers/hwmon/aspeed-chassis.c
@@ -159,7 +159,7 @@
  }
  
  static const struct of_device_id aspeed_chassis_of_table[] = {
-	 { .compatible = "aspeed,ast2700-chassis" },
+	 { .compatible = "aspeed,ast2600-chassis" },
 	 {}
  };
  MODULE_DEVICE_TABLE(of, aspeed_chassis_of_table);


### PR DESCRIPTION
set compatible = "aspeed,ast2600-chassis" as it is in Aspeed SDK and G7 DTSI

Tested:
- Verified in Nigeria