### PR TITLE
arch:arm:dts:chalupa/galena: i2c10 400k

### DIFF
--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-chalupa.dts
@@ -534,6 +534,7 @@
 &i2c10 {
 	// Net name i2c7 (SCM_I2C7)
 	status = "okay";
+	bus-frequency = <400000>;
 	multi-master;
 	mctp-controller;
 	mctp@10 {

--- a/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
+++ b/arch/arm/boot/dts/aspeed/aspeed-bmc-amd-galena.dts
@@ -263,6 +263,7 @@
 &i2c10 {
 	// Net name i2c7
 	status = "okay";
+	bus-frequency = <400000>;
 	multi-master;
 	mctp-controller;
 	mctp@10 {


### PR DESCRIPTION
- make i2c10 freq from 100k to 400k for mi350p pldm fw-update

Verified: Tested on Chalupa & Galena