### PR TITLE
arm64:dts:aspeed: Add Chassis Intrusion driver for SP8

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
@@ -1077,3 +1077,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	non-removable;
 	max-frequency = <200000000>;
 };
+
+&chassis {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
@@ -640,3 +640,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	non-removable;
 	max-frequency = <200000000>;
 };
+
+&chassis {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -1151,3 +1151,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	non-removable;
 	max-frequency = <200000000>;
 };
+
+&chassis {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -877,3 +877,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	non-removable;
 	max-frequency = <200000000>;
 };
+
+&chassis {
+        status = "okay";
+};


### PR DESCRIPTION
Enabling Chassis Intrusion Driver for SP8 platforms

Tested:
- verified in Hornbill and Eagle