### PR TITLE
drivers:hwmon:emc2305: change initial PWM value

### DIFF
--- a/drivers/hwmon/emc2305.c
+++ b/drivers/hwmon/emc2305.c
@@ -18,7 +18,7 @@ emc2305_normal_i2c[] = { 0x27, 0x2c, 0x2d, 0x2e, 0x2f, 0x4c, 0x4d, I2C_CLIENT_EN
 #define EMC2305_REG_DRIVE_FAIL_STATUS	0x27
 #define EMC2305_REG_VENDOR		0xfe
 #define EMC2305_FAN_MAX			0xff
-#define EMC2305_FAN_MIN			0x00
+#define EMC2305_FAN_MIN			0x4c
 #define EMC2305_FAN_MAX_STATE		10
 #define EMC2305_DEVICE			0x34
 #define EMC2305_VENDOR			0x5d


### PR DESCRIPTION
Change initial PWM value from 0 to 0x4C (30%) to avoid issues with the pump fans during initialization.

Tested:
- verified in Morocco