### PR TITLE
arm64:dts:aspeed: Add DIMM devices for SP7

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -898,44 +898,62 @@
 	};
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
-        reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
-        assigned-address = <0x ## addr>; \
-        dcr = /bits/ 8 <0xda>; \
-        bcr = /bits/ 8 <0x6>; \
+	reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
+	assigned-address = <0x ## addr>; \
+	dcr = /bits/ 8 <0xda>; \
+	bcr = /bits/ 8 <0x6>; \
 }
 
-&i3c8 {
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
 
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
 
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -559,8 +559,6 @@
 	};
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -569,58 +567,91 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	bcr = /bits/ 8 <0x6>; \
 }
 
-&i3c8 {
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&i3c9 {
+&i3c3 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub2: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub2: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub3: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub3: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(1, 0, 50);
-	JESD300_SPD_I3C_MODE(1, 1, 51);
-	JESD300_SPD_I3C_MODE(1, 2, 52);
-	JESD300_SPD_I3C_MODE(1, 3, 53);
-	JESD300_SPD_I3C_MODE(1, 4, 54);
-	JESD300_SPD_I3C_MODE(1, 5, 55);
-	JESD300_SPD_I3C_MODE(1, 6, 56);
-	JESD300_SPD_I3C_MODE(1, 7, 57);
+
+	JESD300_SPD_I2C_MODE(1, 0, 50);
+	JESD300_SPD_I2C_MODE(1, 1, 51);
+	JESD300_SPD_I2C_MODE(1, 2, 52);
+	JESD300_SPD_I2C_MODE(1, 3, 53);
+	JESD300_SPD_I2C_MODE(1, 4, 54);
+	JESD300_SPD_I2C_MODE(1, 5, 55);
+	JESD300_SPD_I2C_MODE(1, 6, 56);
+	JESD300_SPD_I2C_MODE(1, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(1, 0, 48);
+	JESD300_PMIC_I2C_MODE(1, 1, 49);
+	JESD300_PMIC_I2C_MODE(1, 2, 4a);
+	JESD300_PMIC_I2C_MODE(1, 3, 4b);
+	JESD300_PMIC_I2C_MODE(1, 4, 4c);
+	JESD300_PMIC_I2C_MODE(1, 5, 4d);
+	JESD300_PMIC_I2C_MODE(1, 6, 4e);
+	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -587,44 +587,62 @@
 	};
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
-        reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
-        assigned-address = <0x ## addr>; \
-        dcr = /bits/ 8 <0xda>; \
-        bcr = /bits/ 8 <0x6>; \
+	reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
+	assigned-address = <0x ## addr>; \
+	dcr = /bits/ 8 <0xda>; \
+	bcr = /bits/ 8 <0x6>; \
 }
 
-&i3c8 {
-        status = "okay";
-        initial-role = "primary";
-        bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
-        internal-pullup = <2>;
-        i3c-scl-hz = <10000000>;
-        i2c-scl-hz = <1000000>;
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
 
-        i3c_hub0: i3chub0@70,4CC00000000 {
-                reg = <0x70 0x4CC 0x00000000>;
-                assigned-address = <0x70>;
-        };
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
 
-        i3c_hub1: i3chub1@71,4CC00000001 {
-                reg = <0x71 0x4CC 0x00000001>;
-                assigned-address = <0x71>;
-        };
+&i3c2 {
+	status = "okay";
+	initial-role = "primary";
+	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
+	internal-pullup = <2>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-        JESD300_SPD_I3C_MODE(0, 0, 50);
-        JESD300_SPD_I3C_MODE(0, 1, 51);
-        JESD300_SPD_I3C_MODE(0, 2, 52);
-        JESD300_SPD_I3C_MODE(0, 3, 53);
-        JESD300_SPD_I3C_MODE(0, 4, 54);
-        JESD300_SPD_I3C_MODE(0, 5, 55);
-        JESD300_SPD_I3C_MODE(0, 6, 56);
-        JESD300_SPD_I3C_MODE(0, 7, 57);
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
+	};
+
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
+	};
+
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1005,67 +1005,99 @@
 	};
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
-        reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
-        assigned-address = <0x ## addr>; \
-        dcr = /bits/ 8 <0xda>; \
-        bcr = /bits/ 8 <0x6>; \
+	reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
+	assigned-address = <0x ## addr>; \
+	dcr = /bits/ 8 <0xda>; \
+	bcr = /bits/ 8 <0x6>; \
 }
-&i3c8 {
+
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&i3c9 {
+&i3c3 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub2: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub2: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub3: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub3: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(1, 0, 50);
-	JESD300_SPD_I3C_MODE(1, 1, 51);
-	JESD300_SPD_I3C_MODE(1, 2, 52);
-	JESD300_SPD_I3C_MODE(1, 3, 53);
-	JESD300_SPD_I3C_MODE(1, 4, 54);
-	JESD300_SPD_I3C_MODE(1, 5, 55);
-	JESD300_SPD_I3C_MODE(1, 6, 56);
-	JESD300_SPD_I3C_MODE(1, 7, 57);
+
+	JESD300_SPD_I2C_MODE(1, 0, 50);
+	JESD300_SPD_I2C_MODE(1, 1, 51);
+	JESD300_SPD_I2C_MODE(1, 2, 52);
+	JESD300_SPD_I2C_MODE(1, 3, 53);
+	JESD300_SPD_I2C_MODE(1, 4, 54);
+	JESD300_SPD_I2C_MODE(1, 5, 55);
+	JESD300_SPD_I2C_MODE(1, 6, 56);
+	JESD300_SPD_I2C_MODE(1, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(1, 0, 48);
+	JESD300_PMIC_I2C_MODE(1, 1, 49);
+	JESD300_PMIC_I2C_MODE(1, 2, 4a);
+	JESD300_PMIC_I2C_MODE(1, 3, 4b);
+	JESD300_PMIC_I2C_MODE(1, 4, 4c);
+	JESD300_PMIC_I2C_MODE(1, 5, 4d);
+	JESD300_PMIC_I2C_MODE(1, 6, 4e);
+	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -776,8 +776,6 @@
 	};
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -786,58 +784,91 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	bcr = /bits/ 8 <0x6>; \
 }
 
-&i3c8 {
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&i3c9 {
+&i3c3 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub2: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub2: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub3: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub3: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(1, 0, 50);
-	JESD300_SPD_I3C_MODE(1, 1, 51);
-	JESD300_SPD_I3C_MODE(1, 2, 52);
-	JESD300_SPD_I3C_MODE(1, 3, 53);
-	JESD300_SPD_I3C_MODE(1, 4, 54);
-	JESD300_SPD_I3C_MODE(1, 5, 55);
-	JESD300_SPD_I3C_MODE(1, 6, 56);
-	JESD300_SPD_I3C_MODE(1, 7, 57);
+
+	JESD300_SPD_I2C_MODE(1, 0, 50);
+	JESD300_SPD_I2C_MODE(1, 1, 51);
+	JESD300_SPD_I2C_MODE(1, 2, 52);
+	JESD300_SPD_I2C_MODE(1, 3, 53);
+	JESD300_SPD_I2C_MODE(1, 4, 54);
+	JESD300_SPD_I2C_MODE(1, 5, 55);
+	JESD300_SPD_I2C_MODE(1, 6, 56);
+	JESD300_SPD_I2C_MODE(1, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(1, 0, 48);
+	JESD300_PMIC_I2C_MODE(1, 1, 49);
+	JESD300_PMIC_I2C_MODE(1, 2, 4a);
+	JESD300_PMIC_I2C_MODE(1, 3, 4b);
+	JESD300_PMIC_I2C_MODE(1, 4, 4c);
+	JESD300_PMIC_I2C_MODE(1, 5, 4d);
+	JESD300_PMIC_I2C_MODE(1, 6, 4e);
+	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";


### PR DESCRIPTION
Add DIMM SPD and PMIC devices to SP7 platforms for i3c2 (P0) and i3c3 (P1).
The i3c buses will run in i2c mode from BMC side.

Tested:
- verified in Congo and Morocco