### PR TITLE
arm64:dts:aspeed: Add DIMM devices for SP8

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
@@ -874,8 +874,6 @@
 	mctp-controller;
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -884,34 +882,54 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         bcr = /bits/ 8 <0x6>; \
 }
 
-&i3c8 {
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
 
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
 
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
@@ -433,8 +433,6 @@
 	mctp-controller;
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -443,34 +441,54 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         bcr = /bits/ 8 <0x6>; \
 }
 
-&i3c8 {
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
 
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
 
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
@@ -851,8 +851,6 @@
 	};
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -860,58 +858,92 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         dcr = /bits/ 8 <0xda>; \
         bcr = /bits/ 8 <0x6>; \
 }
-&i3c8 {
+
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&i3c9 {
+&i3c3 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub2: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub2: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub3: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub3: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(1, 0, 50);
-	JESD300_SPD_I3C_MODE(1, 1, 51);
-	JESD300_SPD_I3C_MODE(1, 2, 52);
-	JESD300_SPD_I3C_MODE(1, 3, 53);
-	JESD300_SPD_I3C_MODE(1, 4, 54);
-	JESD300_SPD_I3C_MODE(1, 5, 55);
-	JESD300_SPD_I3C_MODE(1, 6, 56);
-	JESD300_SPD_I3C_MODE(1, 7, 57);
+
+	JESD300_SPD_I2C_MODE(1, 0, 50);
+	JESD300_SPD_I2C_MODE(1, 1, 51);
+	JESD300_SPD_I2C_MODE(1, 2, 52);
+	JESD300_SPD_I2C_MODE(1, 3, 53);
+	JESD300_SPD_I2C_MODE(1, 4, 54);
+	JESD300_SPD_I2C_MODE(1, 5, 55);
+	JESD300_SPD_I2C_MODE(1, 6, 56);
+	JESD300_SPD_I2C_MODE(1, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(1, 0, 48);
+	JESD300_PMIC_I2C_MODE(1, 1, 49);
+	JESD300_PMIC_I2C_MODE(1, 2, 4a);
+	JESD300_PMIC_I2C_MODE(1, 3, 4b);
+	JESD300_PMIC_I2C_MODE(1, 4, 4c);
+	JESD300_PMIC_I2C_MODE(1, 5, 4d);
+	JESD300_PMIC_I2C_MODE(1, 6, 4e);
+	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -852,8 +852,6 @@
 	};
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -861,58 +859,92 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         dcr = /bits/ 8 <0xda>; \
         bcr = /bits/ 8 <0x6>; \
 }
-&i3c8 {
+
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&i3c9 {
+&i3c3 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub2: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub2: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub3: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub3: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(1, 0, 50);
-	JESD300_SPD_I3C_MODE(1, 1, 51);
-	JESD300_SPD_I3C_MODE(1, 2, 52);
-	JESD300_SPD_I3C_MODE(1, 3, 53);
-	JESD300_SPD_I3C_MODE(1, 4, 54);
-	JESD300_SPD_I3C_MODE(1, 5, 55);
-	JESD300_SPD_I3C_MODE(1, 6, 56);
-	JESD300_SPD_I3C_MODE(1, 7, 57);
+
+	JESD300_SPD_I2C_MODE(1, 0, 50);
+	JESD300_SPD_I2C_MODE(1, 1, 51);
+	JESD300_SPD_I2C_MODE(1, 2, 52);
+	JESD300_SPD_I2C_MODE(1, 3, 53);
+	JESD300_SPD_I2C_MODE(1, 4, 54);
+	JESD300_SPD_I2C_MODE(1, 5, 55);
+	JESD300_SPD_I2C_MODE(1, 6, 56);
+	JESD300_SPD_I2C_MODE(1, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(1, 0, 48);
+	JESD300_PMIC_I2C_MODE(1, 1, 49);
+	JESD300_PMIC_I2C_MODE(1, 2, 4a);
+	JESD300_PMIC_I2C_MODE(1, 3, 4b);
+	JESD300_PMIC_I2C_MODE(1, 4, 4c);
+	JESD300_PMIC_I2C_MODE(1, 5, 4d);
+	JESD300_PMIC_I2C_MODE(1, 6, 4e);
+	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -565,8 +565,6 @@
 	mctp-controller;
 };
 
-#ifdef I3C_HUB
-
 #define JESD300_SPD_I3C_MODE(bus, index, addr) \
 spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
@@ -574,58 +572,92 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
         dcr = /bits/ 8 <0xda>; \
         bcr = /bits/ 8 <0x6>; \
 }
-&i3c8 {
+
+#define JESD300_SPD_I2C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+#define JESD300_PMIC_I2C_MODE(bus, index, addr) \
+pmic_ ## bus ## _ ## index: pmic@addr{ \
+	reg = <0x ## addr 0x0 0x40>; \
+	compatible = "eeprom"; \
+}
+
+&i3c2 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub0: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub0: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub1: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub1: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(0, 0, 50);
-	JESD300_SPD_I3C_MODE(0, 1, 51);
-	JESD300_SPD_I3C_MODE(0, 2, 52);
-	JESD300_SPD_I3C_MODE(0, 3, 53);
-	JESD300_SPD_I3C_MODE(0, 4, 54);
-	JESD300_SPD_I3C_MODE(0, 5, 55);
-	JESD300_SPD_I3C_MODE(0, 6, 56);
-	JESD300_SPD_I3C_MODE(0, 7, 57);
+
+	JESD300_SPD_I2C_MODE(0, 0, 50);
+	JESD300_SPD_I2C_MODE(0, 1, 51);
+	JESD300_SPD_I2C_MODE(0, 2, 52);
+	JESD300_SPD_I2C_MODE(0, 3, 53);
+	JESD300_SPD_I2C_MODE(0, 4, 54);
+	JESD300_SPD_I2C_MODE(0, 5, 55);
+	JESD300_SPD_I2C_MODE(0, 6, 56);
+	JESD300_SPD_I2C_MODE(0, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(0, 0, 48);
+	JESD300_PMIC_I2C_MODE(0, 1, 49);
+	JESD300_PMIC_I2C_MODE(0, 2, 4a);
+	JESD300_PMIC_I2C_MODE(0, 3, 4b);
+	JESD300_PMIC_I2C_MODE(0, 4, 4c);
+	JESD300_PMIC_I2C_MODE(0, 5, 4d);
+	JESD300_PMIC_I2C_MODE(0, 6, 4e);
+	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&i3c9 {
+&i3c3 {
 	status = "okay";
 	initial-role = "primary";
 	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
 	internal-pullup = <2>;
-	i3c-scl-hz = <10000000>;
-	i2c-scl-hz = <1000000>;
+	i3c-scl-hz = <1000000>;
+	i2c-scl-hz = <100000>;
 
-	i3c_hub2: i3chub0@70,4CC00000000 {
-		reg = <0x70 0x4CC 0x00000000>;
-		assigned-address = <0x70>;
+	i3c_hub2: i3chub0@70 {
+		reg = <0x70 0x0 0x40>;
+		compatible = "none";
 	};
-	i3c_hub3: i3chub1@71,4CC00000001 {
-		reg = <0x71 0x4CC 0x00000001>;
-		assigned-address = <0x71>;
+
+	i3c_hub3: i3chub1@71 {
+		reg = <0x71 0x0 0x40>;
+		compatible = "none";
 	};
-	JESD300_SPD_I3C_MODE(1, 0, 50);
-	JESD300_SPD_I3C_MODE(1, 1, 51);
-	JESD300_SPD_I3C_MODE(1, 2, 52);
-	JESD300_SPD_I3C_MODE(1, 3, 53);
-	JESD300_SPD_I3C_MODE(1, 4, 54);
-	JESD300_SPD_I3C_MODE(1, 5, 55);
-	JESD300_SPD_I3C_MODE(1, 6, 56);
-	JESD300_SPD_I3C_MODE(1, 7, 57);
+
+	JESD300_SPD_I2C_MODE(1, 0, 50);
+	JESD300_SPD_I2C_MODE(1, 1, 51);
+	JESD300_SPD_I2C_MODE(1, 2, 52);
+	JESD300_SPD_I2C_MODE(1, 3, 53);
+	JESD300_SPD_I2C_MODE(1, 4, 54);
+	JESD300_SPD_I2C_MODE(1, 5, 55);
+	JESD300_SPD_I2C_MODE(1, 6, 56);
+	JESD300_SPD_I2C_MODE(1, 7, 57);
+
+	JESD300_PMIC_I2C_MODE(1, 0, 48);
+	JESD300_PMIC_I2C_MODE(1, 1, 49);
+	JESD300_PMIC_I2C_MODE(1, 2, 4a);
+	JESD300_PMIC_I2C_MODE(1, 3, 4b);
+	JESD300_PMIC_I2C_MODE(1, 4, 4c);
+	JESD300_PMIC_I2C_MODE(1, 5, 4d);
+	JESD300_PMIC_I2C_MODE(1, 6, 4e);
+	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
-#endif
 
 &gpio0 {
 	status = "okay";


### PR DESCRIPTION
Add DIMM SPD and PMIC devices to SP8 platforms for i3c2 (P0) and i3c3 (P1).

Tested:
    - verified in Seagull