### PR TITLE
arm64:dts:aspeed: Add Arthur BMC device tree

### DIFF
--- a/arch/arm64/boot/dts/aspeed/Makefile
+++ b/arch/arm64/boot/dts/aspeed/Makefile
@@ -11,3 +11,4 @@ dtb-$(CONFIG_ARCH_ASPEED) += \
 	aspeed-bmc-amd-nigeria.dtb \
 	aspeed-bmc-amd-nigerias3.dtb \
 	aspeed-bmc-amd-seagull.dtb \
+	aspeed-bmc-amd-arthur.dtb \

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
@@ -48,6 +48,25 @@
 			reusable;
 		};
 	};
+
+	aliases {
+		i2c100 = &P0_conn_012_cpu;
+		i2c101 = &P0_conn_345_cpu;
+		i2c102 = &P0_conn_012_mgmt;
+		i2c103 = &P0_conn_345_mgmt;
+		i2c104 = &fan_pdb;
+		i2c105 = &P0_pcp;
+		i2c106 = &NC_5;
+		i2c107 = &NC_6;
+		i2c200 = &picpwr_fan_0;
+		i2c201 = &picpwr_fan_1;
+		i2c202 = &picpwr_pdb;
+		i2c203 = &churro_fans_0_0;
+		i2c204 = &churro_fans_0_1;
+		i2c205 = &churro_id;
+		i2c206 = &churro_mcu;
+		i2c207 = &NC_7;
+	};
 };
 
 &mdio0 {
@@ -172,14 +191,20 @@
 };
 
 &i2c0 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
 	status = "okay";
 };
 
 &i2c1 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
 	status = "okay";
 };
 
 &i2c2 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
 	status = "okay";
 };
 
@@ -232,7 +257,171 @@
 };
 
 &i2c12 {
+	// Net name i2c2 (SCM_I2C_SDA<2>) - FAN/LM75/ADC
 	status = "okay";
+	clock-frequency = <400000>;
+
+	i2cswitch@70 {
+		compatible = "nxp,pca9548";
+		reg = <0x70>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		i2c-mux-idle-disconnect;
+
+		P0_conn_012_cpu: i2c@0 {
+			reg = <0>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		P0_conn_345_cpu: i2c@1 {
+			reg = <1>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		P0_conn_012_mgmt: i2c@2 {
+			reg = <2>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		P0_conn_345_mgmt: i2c@3 {
+			reg = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		fan_pdb: i2c@4 {
+			reg = <4>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+			i2cswitch@71 {
+				compatible = "nxp,pca9546";
+				reg = <0x71>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+
+				picpwr_fan_0: i2c@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					i2cswitch@76 {
+						compatible = "nxp,pca9546";
+						reg = <0x76>;
+						#address-cells = <1>;
+						#size-cells = <0>;
+
+						churro_fans_0_0: i2c@0 {
+							reg = <0>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							emc2305@4d {
+								compatible = "smsc,emc2305";
+								reg = <0x4d>;
+								#cooling-cells = <0x02>;
+
+								fan@0 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@1 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@2 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@3 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+							};
+						};
+
+						churro_fans_0_1: i2c@1 {
+							reg = <1>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+
+							emc2305@4d {
+								compatible = "smsc,emc2305";
+								reg = <0x4d>;
+								#cooling-cells = <0x02>;
+
+								fan@0 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@1 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@2 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+								fan@3 {
+									min-rpm = /bits/ 16 <1000>;
+									max-rpm = /bits/ 16 <16000>;
+								};
+							};
+						};
+
+						churro_id: i2c@2 {
+							reg = <2>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+						};
+
+						churro_mcu: i2c@3 {
+							reg = <3>;
+							#address-cells = <1>;
+							#size-cells = <0>;
+						};
+					};
+				};
+
+				picpwr_fan_1: i2c@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+
+				picpwr_pdb: i2c@2 {
+					reg = <2>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+
+				NC_7: i2c@3 {
+					reg = <3>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+			};
+		};
+
+		P0_pcp: i2c@5 {
+			reg = <5>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		NC_5: i2c@6 {
+			reg = <6>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+
+		NC_6: i2c@7 {
+			reg = <7>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+		};
+	};
 };
 
 &i2c13 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2026 AMD Inc.
+// Author: Rajaganesh Rathinasabapathi <Rajaganesh.Rathinasabapathi@amd.com>
+
+/dts-v1/;
+
+#include "aspeed-g7.dtsi"
+#include "dt-bindings/gpio/aspeed-gpio.h"
+#include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/i3c/i3c.h>
+
+#define PCIE0_EP 1      // 1: EP, 0: RC
+#define PCIE1_EP 1      // 1: EP, 0: RC
+#define I3C_HUB
+
+/ {
+	model = "AMD Arthur VRB";
+	compatible = "amd,arthur-bmc", "aspeed,ast2700";
+
+	chosen {
+		stdout-path = &uart12;
+		bootargs = "console=ttyS12,115200n8";
+	};
+
+	firmware {
+		optee: optee {
+			compatible = "linaro,optee-tz";
+			method = "smc";
+		};
+	};
+
+	memory@400000000 {
+		device_type = "memory";
+		reg = <0x4 0x00000000 0x0 0x80000000>;
+	};
+
+	reserved-memory {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		#include "ast2700-reserved-mem.dtsi"
+
+		video_engine_memory0: video0 {
+			size = <0x0 0x04000000>;
+			alignment = <0x0 0x00010000>;
+			compatible = "shared-dma-pool";
+			reusable;
+		};
+	};
+};
+
+&mdio0 {
+	status = "okay";
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	ethphy0: ethernet-phy@0 {
+		compatible = "ethernet-phy-ieee802.3-c22";
+		reg = <0>;
+	};
+};
+
+&pinctrl1 {
+	pinctrl_rgmii0_driving: rgmii0_driving {
+		pins = "C20", "C19", "A8", "R14", "A7", "P14",
+		       "D20", "A6", "B6", "N14", "B7", "B8";
+		drive-strength = <1>;
+	};
+};
+
+&mac0 {
+	status = "okay";
+	phy-mode = "rgmii-id";
+	phy-handle = <&ethphy0>;
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rgmii0_default &pinctrl_rgmii0_driving>;
+};
+
+&mac1 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&pinctrl_rmii1_default>;
+	clock-names = "MACCLK", "RCLK";
+	phy-mode = "rmii";
+	use-ncsi;
+};
+
+&fmc {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_fwspi_quad_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "bmc";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+#include "amd-flash-layout-128.dtsi"
+	};
+
+	flash@1 {
+		status = "okay";
+		m25p,fast-read;
+		label = "mpflash";
+		spi-max-frequency = <50000000>;
+		spi-tx-bus-width = <4>;
+		spi-rx-bus-width = <4>;
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi0_default &pinctrl_spi0_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <33000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+&spi1 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi1_default &pinctrl_spi1_cs1_default>;
+	pinctrl-names = "default";
+
+	flash@0 {
+		status = "okay";
+		m25p,fast-read;
+		label = "pnor";
+		spi-max-frequency = <33000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+&spi2 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_spi2_default &pinctrl_spi2_cs1_default>;
+	pinctrl-names = "default";
+	compatible = "aspeed,ast2700-spi-txrx";
+	flash@0 {
+		reg = <0>;
+		status = "disabled";
+		m25p,fast-read;
+		label = "pnor";
+		compatible = "jedec,spi-nor";
+		spi-max-frequency = <33000000>;
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+	oled@0 {
+		reg = <0>;
+		compatible = "ssd,ssd1322";
+		spi-max-frequency = <1000000>;
+		label = "ssd1322";
+		status = "okay";
+		spi-tx-bus-width = <1>;
+		spi-rx-bus-width = <1>;
+	};
+};
+
+&uart12 {
+	status = "okay";
+};
+
+&i2c0 {
+	status = "okay";
+};
+
+&i2c1 {
+	status = "okay";
+};
+
+&i2c2 {
+	status = "okay";
+};
+
+&i2c3 {
+	status = "okay";
+};
+
+&i2c4 {
+	status = "okay";
+};
+
+&i2c5 {
+	status = "okay";
+};
+
+&i2c6 {
+	status = "okay";
+};
+
+&i2c7 {
+	status = "okay";
+	clock-frequency = <400000>;
+
+	scmeeprom@50 {
+		compatible = "atmel,24c08";
+		reg = <0x50>;
+	};
+};
+
+&i2c8 {
+	status = "okay";
+	clock-frequency = <400000>;
+
+	hpmeeprom@50 {
+		compatible = "microchip,24lc256", "atmel,24c256";
+		reg = <0x50>;
+	};
+};
+
+&i2c9 {
+	status = "okay";
+};
+
+&i2c10 {
+	status = "okay";
+};
+
+&i2c11 {
+	status = "okay";
+};
+
+&i2c12 {
+	status = "okay";
+};
+
+&i2c13 {
+	status = "okay";
+};
+
+&i2c14 {
+	status = "okay";
+};
+
+&i2c15 {
+	status = "okay";
+};
+
+&i3c4 {
+	status = "okay";
+	initial-role = "primary";
+	internal-pullup = <2>;
+	i3c-scl-hz = <12500000>;
+	i2c-scl-hz = <1000000>;
+	mctp-controller;
+};
+
+#ifdef I3C_HUB
+
+#define JESD300_SPD_I3C_MODE(bus, index, addr) \
+spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
+	reg = <0x ## addr 0x4cc 0x5118 ## index ## 000>; \
+	assigned-address = <0x ## addr>; \
+	dcr = /bits/ 8 <0xda>; \
+	bcr = /bits/ 8 <0x6>; \
+}
+
+&i3c8 {
+	status = "okay";
+	initial-role = "primary";
+	bus-context = /bits/ 8 <I3C_BUS_CONTEXT_JESD403>;
+	internal-pullup = <2>;
+	i3c-scl-hz = <10000000>;
+	i2c-scl-hz = <1000000>;
+
+	i3c_hub0: i3chub0@70,4CC00000000 {
+		reg = <0x70 0x4CC 0x00000000>;
+		assigned-address = <0x70>;
+	};
+
+	/* SB1 1P: 6 DIMMs on hub0 target ports 0-5 (0x50-0x55). */
+	JESD300_SPD_I3C_MODE(0, 0, 50);
+	JESD300_SPD_I3C_MODE(0, 1, 51);
+	JESD300_SPD_I3C_MODE(0, 2, 52);
+	JESD300_SPD_I3C_MODE(0, 3, 53);
+	JESD300_SPD_I3C_MODE(0, 4, 54);
+	JESD300_SPD_I3C_MODE(0, 5, 55);
+};
+#endif
+
+&gpio0 {
+	status = "okay";
+
+	p0_sec_i2c {
+		gpio-hog;
+		gpios = <8 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "SEL_P0_SEC_I2C_ROT_BMC";
+	};
+};
+
+&ltpi0 {
+	status = "okay";
+};
+
+&ltpi0_gpio {
+	status = "okay";
+	gpio-line-names =
+		/*00-07*/ "","","",
+			"P0_MGMT_ASSERT_CLR_CMOS","P0_MGMT_MON_PROCHOT_L","P0_MGMT_ASSERT_PROCHOT_L",
+			"P0_MGMT_MON_RSMRST_L","P0_ASSERT_RSMRST",
+		/*08-15*/ "P0_MGMT_MON_THERMTRIP_L","P0_MGMT_ASSERT_THERMTRIP_L","P0_PRESENT_L",
+			"","P1_PRESENT_L","",
+			"P0_MGMT_MON_POST_COMPLETE","",
+		/*16-23*/ "P0_MGMT_MON_PWR_GOOD","","P0_MGMT_MON_PSP_SOFT_FUSE_NTFY",
+			"","P0_I3C_APML_ALERT_L","",
+			"MGMT_SYS_MON_ATX_PWR_OK","",
+		/*24-31*/ "","","","","","","","P0_MGMT_ASSERT_NMI_BTN_L",
+		/*32-39*/ "","P0_MGMT_SOC_RESET_L","",
+			"MGMT_HDT_SEL","","SCM_JTAG_DBREQ","","JTAG_TRST_N",
+		/*40-47*/ "","P0_MGMT_ASSERT_WARM_RST_BTN_L","P0_MGMT_MON_DIMM_AH_PCAMP","","P0_MGMT_MON_DIMM_IP_PCAMP","","","",
+		/*48-55*/ "","","","","","","","",
+		/*56-63*/ "","","","","","","","",
+		/*64-71*/ "","","","","","","","",
+		/*72-79*/ "","","","","","","","",
+		/*80-87*/ "","","","","","","","",
+		/*88-95*/ "","","","","","","","",
+		/*96-103*/ "","","","","","","","",
+		/*104-111*/ "","","MGMT_MON_INTR_CHASSIS_L","","","HPM_STBY_EN","","",
+		/*112-119*/ "","","","","","","","",
+		/*120-127*/ "","","","","","","","",
+		/*128-135*/ "P0_MGMT_MON_RST_BTN_L","P0_MGMT_ASSERT_RST_BTN_L","P0_MGMT_MON_PWR_BTN_L",
+			"P0_MGMT_ASSERT_PWR_BTN_L","","",
+			"","",
+		/*136-143*/ "","","","","","","","",
+		/*144-151*/ "","","","","","","","",
+		/*152-159*/ "","","","","","","","",
+		/*160-167*/ "","","","","","","","",
+		/*168-175*/ "","","","","","","","",
+		/*176-183*/ "","","","","","","","",
+		/*184-191*/ "","","","","","","","",
+		/*192-199*/ "","","","","","","","",
+		/*200-207*/ "","","","","","","","",
+		/*208-215*/ "","","","","","","","",
+		/*216-223*/ "","","","","","","","";
+};
+
+&video0 {
+	status = "okay";
+	memory-region = <&video_engine_memory0>;
+};
+
+&espi0 {
+	status = "okay";
+	perif-dma-mode;
+	perif-mmbi-enable;
+	perif-mmbi-src-addr = <0x0 0xa8000000>;
+	perif-mmbi-tgt-memory = <&espi0_mmbi_memory>;
+	perif-mmbi-instance-num = <0x1>;
+	perif-mcyc-enable;
+	perif-mcyc-src-addr = <0x0 0x98000000>;
+	perif-mcyc-size = <0x0 0x10000>;
+	oob-dma-mode;
+	flash-dma-mode;
+	flash-edaf-mode = <0>;
+	flash-edaf-tgt-addr = <0x1 0x80000000>;
+	flash-edaf-size = <0x0 0x2000000>;
+};
+
+&lpc0_pcc {
+	pcc-ports = <0x80>;
+	status = "okay";
+};
+
+&uart13 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+	status = "okay";
+};
+
+&vuart0 {
+	status = "okay";
+	virtual;
+	port = <0x3f8>;
+	sirq = <4>;
+	sirq-polarity = <0>;
+};
+
+&uphy3a {
+	status = "okay";
+};
+
+&vhuba0 {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_usb2ahpd0_default>;
+};
+
+&usb3ahp {
+	status = "okay";
+	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+};
+
+&xdma0 {
+	status = "okay";
+	memory-region = <&xdma_memory0>;
+};
+
+&lpc0_kcs2 {
+	status = "okay";
+	kcs-io-addr = <0xca2>;
+	kcs-channel = <2>;
+};
+
+&jtag1 {
+	status = "okay";
+};
+
+&mctp0 {
+	status = "okay";
+	memory-region = <&mctp0_reserved>;
+	mctp-controller;
+};
+
+&bmc_dev0 {
+	status = "okay";
+	memory-region = <&bmc_dev0_memory>;
+};
+
+&emmc_controller {
+	status = "okay";
+	mmc-hs200-1_8v;
+};
+
+&emmc {
+	status = "okay";
+	bus-width = <4>;
+	pinctrl-0 = <&pinctrl_emmc_default>;
+	non-removable;
+	max-frequency = <200000000>;
+};
+
+&chassis {
+	status = "okay";
+};
+
+/ {
+	alertl_sock0 {
+		compatible = "apml-alertl";
+		status = "okay";
+		socket-num = /bits/ 8 <0>;
+		gpios = <&ltpi0_gpio 20 GPIO_ACTIVE_LOW>;
+	};
+};

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
@@ -50,22 +50,22 @@
 	};
 
 	aliases {
-		i2c100 = &P0_conn_012_cpu;
-		i2c101 = &P0_conn_345_cpu;
-		i2c102 = &P0_conn_012_mgmt;
-		i2c103 = &P0_conn_345_mgmt;
-		i2c104 = &fan_pdb;
-		i2c105 = &P0_pcp;
-		i2c106 = &NC_5;
-		i2c107 = &NC_6;
-		i2c200 = &picpwr_fan_0;
-		i2c201 = &picpwr_fan_1;
-		i2c202 = &fan_board_ch2;
+		i2c100 = &arthur_local_fans_0;
+		i2c101 = &arthur_local_fans_1;
+		i2c102 = &arthur_fan_board_ch2;
+		i2c103 = &arthur_fan_board_ch3;
+		i2c104 = &arthur_fan_board_ch2;
+		i2c105 = &arthur_fan_board_ch3;
+		i2c200 = &arthur_local_fans_0;
+		i2c201 = &arthur_local_fans_1;
+		i2c202 = &arthur_fan_board_ch2;
 		i2c203 = &churro_fans_0_0;
 		i2c204 = &churro_fans_0_1;
-		i2c205 = &fan_2u_mux;
-		i2c206 = &fan_2u_ctrl0;
-		i2c207 = &fan_2u_ctrl1;
+		i2c205 = &arthur_2u_mux;
+		i2c206 = &arthur_2u_ctrl0;
+		i2c207 = &arthur_2u_ctrl1;
+		i2c208 = &churro_fans_1_0;
+		i2c209 = &churro_fans_1_1;
 	};
 };
 
@@ -269,7 +269,7 @@
 		i2c-mux-idle-disconnect;
 
 		/* Local fan controller 0 (mux channel 0) */
-		P0_conn_012_cpu: picpwr_fan_0: i2c@0 {
+		arthur_local_fans_0: i2c@0 {
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -303,7 +303,7 @@
 		};
 
 		/* Local fan controller 1 (mux channel 1) */
-		P0_conn_345_cpu: picpwr_fan_1: i2c@1 {
+		arthur_local_fans_1: i2c@1 {
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -337,51 +337,50 @@
 		};
 
 		/*
-		 * Mux channel 2 superset mapping:
-		 * - Churro variant: direct EMC2305 @0x4d
-		 * - 2U fan board variant: downstream PCA9548 @0x76 with
-		 *   NCT7363Y on channels 0/1 @0x20
+		 * Mux channel 2 -> Churro/2U fan-board superset path.
+		 * TODO: split DT variants once 0x76 mux type is finalized per board
+		 * (Churro uses TCA9546, 2U fan board uses TCA9548).
 		 */
-		P0_conn_012_mgmt: fan_pdb: fan_board_ch2: churro_fans_0_0: i2c@2 {
+		arthur_fan_board_ch2: i2c@2 {
 			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			emc2305@4d {
-				compatible = "smsc,emc2305";
-				reg = <0x4d>;
-				#cooling-cells = <0x02>;
-
-				fan@0 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
-				};
-				fan@1 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
-				};
-				fan@2 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
-				};
-				fan@3 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
-				};
-			};
-
-			fan_2u_mux: i2cswitch@76 {
-				compatible = "nxp,pca9548";
+			arthur_2u_mux: i2cswitch@76 {
+				compatible = "nxp,pca9546";
 				reg = <0x76>;
 				#address-cells = <1>;
 				#size-cells = <0>;
 				i2c-mux-idle-disconnect;
 
-				fan_2u_ctrl0: i2c@0 {
+				arthur_2u_ctrl0: churro_fans_0_0: i2c@0 {
 					reg = <0>;
 					#address-cells = <1>;
 					#size-cells = <0>;
 
+					emc2305@4d {
+						compatible = "smsc,emc2305";
+						reg = <0x4d>;
+						#cooling-cells = <0x02>;
+
+						fan@0 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@1 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@2 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@3 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+					};
+
 					nct7363@20 {
 						compatible = "nct,nct7363";
 						reg = <0x20>;
@@ -389,50 +388,136 @@
 					};
 				};
 
-				fan_2u_ctrl1: i2c@1 {
+				arthur_2u_ctrl1: churro_fans_0_1: i2c@1 {
 					reg = <1>;
 					#address-cells = <1>;
 					#size-cells = <0>;
 
+					emc2305@4d {
+						compatible = "smsc,emc2305";
+						reg = <0x4d>;
+						#cooling-cells = <0x02>;
+
+						fan@0 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@1 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@2 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@3 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+					};
+
 					nct7363@20 {
 						compatible = "nct,nct7363";
 						reg = <0x20>;
 						fan_sel_gpio = <3>;
 					};
 				};
+
+				churro_id: i2c@2 {
+					reg = <2>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
+
+				churro_mcu: i2c@3 {
+					reg = <3>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+				};
 			};
 		};
 
-		/*
-		 * Mux channel 3 mapping:
-		 * - Churro variant: EMC2305 @0x4d
-		 * - 2U fan board variant: reserved (no probe expected)
-		 */
-		P0_conn_345_mgmt: P0_pcp: NC_5: NC_6: churro_fans_0_1: i2c@3 {
+		/* Mux channel 3 -> second Churro/2U fan-board superset path */
+		arthur_fan_board_ch3: i2c@3 {
 			reg = <3>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			emc2305@4d {
-				compatible = "smsc,emc2305";
-				reg = <0x4d>;
-				#cooling-cells = <0x02>;
+			i2cswitch@76 {
+				compatible = "nxp,pca9546";
+				reg = <0x76>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				i2c-mux-idle-disconnect;
 
-				fan@0 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
+				churro_fans_1_0: i2c@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					emc2305@4d {
+						compatible = "smsc,emc2305";
+						reg = <0x4d>;
+						#cooling-cells = <0x02>;
+
+						fan@0 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@1 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@2 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@3 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+					};
 				};
-				fan@1 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
+
+				churro_fans_1_1: i2c@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					emc2305@4d {
+						compatible = "smsc,emc2305";
+						reg = <0x4d>;
+						#cooling-cells = <0x02>;
+
+						fan@0 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@1 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@2 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+						fan@3 {
+							min-rpm = /bits/ 16 <1000>;
+							max-rpm = /bits/ 16 <16000>;
+						};
+					};
 				};
-				fan@2 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
+
+				churro1_id: i2c@2 {
+					reg = <2>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 				};
-				fan@3 {
-					min-rpm = /bits/ 16 <1000>;
-					max-rpm = /bits/ 16 <16000>;
+
+				churro1_mcu: i2c@3 {
+					reg = <3>;
+					#address-cells = <1>;
+					#size-cells = <0>;
 				};
 			};
 		};
@@ -501,6 +586,18 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		gpios = <8 GPIO_ACTIVE_HIGH>;
 		output-high;
 		line-name = "SEL_P0_SEC_I2C_ROT_BMC";
+	};
+
+};
+
+&gpio1 {
+	status = "okay";
+	/* Rev-B HPM EN line on gpiochip1 C7 */
+	hpm_en_rev_b_default {
+		gpio-hog;
+		gpios = <33 GPIO_ACTIVE_HIGH>;
+		output-high;
+		line-name = "HPM_EN_GPIO_REV_B";
 	};
 };
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
@@ -60,12 +60,12 @@
 		i2c107 = &NC_6;
 		i2c200 = &picpwr_fan_0;
 		i2c201 = &picpwr_fan_1;
-		i2c202 = &picpwr_pdb;
+		i2c202 = &fan_board_ch2;
 		i2c203 = &churro_fans_0_0;
 		i2c204 = &churro_fans_0_1;
-		i2c205 = &churro_id;
-		i2c206 = &churro_mcu;
-		i2c207 = &NC_7;
+		i2c205 = &fan_2u_mux;
+		i2c206 = &fan_2u_ctrl0;
+		i2c207 = &fan_2u_ctrl1;
 	};
 };
 
@@ -261,165 +261,180 @@
 	status = "okay";
 	clock-frequency = <400000>;
 
-	i2cswitch@70 {
-		compatible = "nxp,pca9548";
-		reg = <0x70>;
+	i2cswitch@75 {
+		compatible = "nxp,pca9546";
+		reg = <0x75>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		i2c-mux-idle-disconnect;
 
-		P0_conn_012_cpu: i2c@0 {
+		/* Local fan controller 0 (mux channel 0) */
+		P0_conn_012_cpu: picpwr_fan_0: i2c@0 {
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-		};
 
-		P0_conn_345_cpu: i2c@1 {
-			reg = <1>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
 
-		P0_conn_012_mgmt: i2c@2 {
-			reg = <2>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		P0_conn_345_mgmt: i2c@3 {
-			reg = <3>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		fan_pdb: i2c@4 {
-			reg = <4>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-			i2cswitch@71 {
-				compatible = "nxp,pca9546";
-				reg = <0x71>;
-				#address-cells = <1>;
-				#size-cells = <0>;
-
-				picpwr_fan_0: i2c@0 {
-					reg = <0>;
-					#address-cells = <1>;
-					#size-cells = <0>;
-					i2cswitch@76 {
-						compatible = "nxp,pca9546";
-						reg = <0x76>;
-						#address-cells = <1>;
-						#size-cells = <0>;
-
-						churro_fans_0_0: i2c@0 {
-							reg = <0>;
-							#address-cells = <1>;
-							#size-cells = <0>;
-
-							emc2305@4d {
-								compatible = "smsc,emc2305";
-								reg = <0x4d>;
-								#cooling-cells = <0x02>;
-
-								fan@0 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-								fan@1 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-								fan@2 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-								fan@3 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-							};
-						};
-
-						churro_fans_0_1: i2c@1 {
-							reg = <1>;
-							#address-cells = <1>;
-							#size-cells = <0>;
-
-							emc2305@4d {
-								compatible = "smsc,emc2305";
-								reg = <0x4d>;
-								#cooling-cells = <0x02>;
-
-								fan@0 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-								fan@1 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-								fan@2 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-								fan@3 {
-									min-rpm = /bits/ 16 <1000>;
-									max-rpm = /bits/ 16 <16000>;
-								};
-							};
-						};
-
-						churro_id: i2c@2 {
-							reg = <2>;
-							#address-cells = <1>;
-							#size-cells = <0>;
-						};
-
-						churro_mcu: i2c@3 {
-							reg = <3>;
-							#address-cells = <1>;
-							#size-cells = <0>;
-						};
-					};
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
 				};
-
-				picpwr_fan_1: i2c@1 {
-					reg = <1>;
-					#address-cells = <1>;
-					#size-cells = <0>;
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
 				};
-
-				picpwr_pdb: i2c@2 {
-					reg = <2>;
-					#address-cells = <1>;
-					#size-cells = <0>;
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
 				};
-
-				NC_7: i2c@3 {
-					reg = <3>;
-					#address-cells = <1>;
-					#size-cells = <0>;
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
 				};
 			};
 		};
 
-		P0_pcp: i2c@5 {
-			reg = <5>;
+		/* Local fan controller 1 (mux channel 1) */
+		P0_conn_345_cpu: picpwr_fan_1: i2c@1 {
+			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@4 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
 		};
 
-		NC_5: i2c@6 {
-			reg = <6>;
+		/*
+		 * Mux channel 2 superset mapping:
+		 * - Churro variant: direct EMC2305 @0x4d
+		 * - 2U fan board variant: downstream PCA9548 @0x76 with
+		 *   NCT7363Y on channels 0/1 @0x20
+		 */
+		P0_conn_012_mgmt: fan_pdb: fan_board_ch2: churro_fans_0_0: i2c@2 {
+			reg = <2>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
+
+			fan_2u_mux: i2cswitch@76 {
+				compatible = "nxp,pca9548";
+				reg = <0x76>;
+				#address-cells = <1>;
+				#size-cells = <0>;
+				i2c-mux-idle-disconnect;
+
+				fan_2u_ctrl0: i2c@0 {
+					reg = <0>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					nct7363@20 {
+						compatible = "nct,nct7363";
+						reg = <0x20>;
+						fan_sel_gpio = <3>;
+					};
+				};
+
+				fan_2u_ctrl1: i2c@1 {
+					reg = <1>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+
+					nct7363@20 {
+						compatible = "nct,nct7363";
+						reg = <0x20>;
+						fan_sel_gpio = <3>;
+					};
+				};
+			};
 		};
 
-		NC_6: i2c@7 {
-			reg = <7>;
+		/*
+		 * Mux channel 3 mapping:
+		 * - Churro variant: EMC2305 @0x4d
+		 * - 2U fan board variant: reserved (no probe expected)
+		 */
+		P0_conn_345_mgmt: P0_pcp: NC_5: NC_6: churro_fans_0_1: i2c@3 {
+			reg = <3>;
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			emc2305@4d {
+				compatible = "smsc,emc2305";
+				reg = <0x4d>;
+				#cooling-cells = <0x02>;
+
+				fan@0 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@1 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@2 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+				fan@3 {
+					min-rpm = /bits/ 16 <1000>;
+					max-rpm = /bits/ 16 <16000>;
+				};
+			};
 		};
 	};
 };


### PR DESCRIPTION
Add aspeed-bmc-amd-arthur.dts for the AMD Arthur system and register the DTB in the aspeed Makefile.

Tested: Verified in A2 Bahama