### PR TITLE
arm64:dts:aspeed: SP7 PRB disconnect all Ch when idle

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -287,6 +287,30 @@
 		compatible = "microchip,24lc256","atmel,24c256";
 		reg = <0x50>;
 	};
+
+	i2cswitch@71 {
+		compatible = "nxp,pca9548";
+		reg = <0x71>;
+		i2c-mux-idle-disconnect;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2cswitch@72 {
+		compatible = "nxp,pca9546";
+		reg = <0x72>;
+		i2c-mux-idle-disconnect;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
+
+	i2cswitch@74 {
+		compatible = "nxp,pca9546";
+		reg = <0x74>;
+		i2c-mux-idle-disconnect;
+		#address-cells = <1>;
+		#size-cells = <0>;
+	};
 };
 
 &i2c9 {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -298,65 +298,19 @@
 		compatible = "microchip,24lc256","atmel,24c256";
 		reg = <0x50>;
 	};
-#ifdef PDB
+
 	i2cswitch@71 {
 		compatible = "nxp,pca9548";
 		reg = <0x71>;
+		i2c-mux-idle-disconnect;
 		#address-cells = <1>;
 		#size-cells = <0>;
-
-		riser_1A: i2c@0 {
-			reg = <0>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		riser_1B: i2c@1 {
-			reg = <1>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		riser_2A: i2c@2 {
-			reg = <2>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		riser_3A: i2c@3 {
-			reg = <3>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		riser_3B: i2c@4 {
-			reg = <4>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		m2: i2c@5 {
-			reg = <5>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		ocp: i2c@6 {
-			reg = <6>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
-
-		pdb: i2c@7 {
-			reg = <7>;
-			#address-cells = <1>;
-			#size-cells = <0>;
-		};
 	};
-#endif
+
 	i2cswitch@72 {
 		compatible = "nxp,pca9548";
 		reg = <0x72>;
+		i2c-mux-idle-disconnect;
 		#address-cells = <1>;
 		#size-cells = <0>;
 

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -338,6 +338,7 @@
 	i2cswitch@70 {
 		compatible = "nxp,pca9548";
 		reg = <0x70>;
+		i2c-mux-idle-disconnect;
 		#address-cells = <1>;
 		#size-cells = <0>;
 


### PR DESCRIPTION
in SP7 PRB systems:
- requested I²C mux driver to disconnect all downstream channels when idle.
- this will prevent HPM FRU Read corruption from PCIe cards on i2c-8

Tested:
- verified in SP7 PRB systems