### PR TITLE
arm64: dts: ghana: Configure Venice RMI/TSI devs

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -538,6 +538,26 @@
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
 
+	sbtsi_p0_iod0: sbtsi@0,22400000118 {
+		reg = <0x0 0x224 0x00000118>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_iod0: sbrmi@0,22400001118 {
+		reg = <0x0 0x224 0x00001118>;
+		assigned-address = <0x3c>;
+	};
+
+	sbtsi_p0_iod0_AB: sbtsi@0,22400000119 {
+		reg = <0x0 0x224 0x00000119>;
+		assigned-address = <0x4c>;
+	};
+
+	sbrmi_p0_iod0_AB: sbrmi@0,22400001119 {
+		reg = <0x0 0x224 0x00001119>;
+		assigned-address = <0x3c>;
+	};
+
 	scoob_p0: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;
 		mrl = <69>;
@@ -558,6 +578,54 @@
 	i3c-scl-hz = <12500000>;
 	i2c-scl-hz = <1000000>;
 	mctp-controller;
+
+	/* TSI Venice A0 2P */
+	sbtsi_p1_iod0: sbtsi@0,22401000118 {
+		reg = <0x0 0x224 0x01000118>;
+		assigned-address = <0x48>;
+	};
+
+	/* RMI Venice A0 2P */
+	sbrmi_p1_iod0: sbrmi@0,22401001118 {
+		reg = <0x0 0x224 0x01001118>;
+		assigned-address = <0x38>;
+	};
+
+	/* TSI Venice A0 2X1P */
+	sbtsi_2x1p_p1_iod0: sbtsi@0,22400000118 {
+		reg = <0x0 0x224 0x00000118>;
+		assigned-address = <0x48>;
+	};
+
+	/* RMI Venice A0 2X1P */
+	sbrmi_2x1p_p1_iod0: sbrmi@0,22400001118 {
+		reg = <0x0 0x224 0x00001118>;
+		assigned-address = <0x38>;
+	};
+
+	/* TSI Venice AB/B0 2P */
+	sbtsi_p1_iod0_AB: sbtsi@0,22401000119 {
+		reg = <0x0 0x224 0x01000119>;
+		assigned-address = <0x48>;
+	};
+
+	/* RMI Venice AB/B0 2P */
+	sbrmi_p1_iod0_AB: sbrmi@0,22401001119 {
+		reg = <0x0 0x224 0x01001119>;
+		assigned-address = <0x38>;
+	};
+
+	/* TSI Venice AB/B0 2x1P */
+	sbtsi_2x1p_p1_AB_iod0: sbtsi@0,22400000119 {
+		reg = <0x0 0x224 0x00000119>;
+		assigned-address = <0x48>;
+	};
+
+	/* RMI Venice AB/B0 2x1P */
+	sbrmi_2x1p_p1_AB_iod0: sbrmi@0,22400001119 {
+		reg = <0x0 0x224 0x00001119>;
+		assigned-address = <0x38>;
+	};
 
 	scoob_2x1p_p1: scoob@0,22400002118 {
 		reg = <0x0 0x224 0x00002118>;


### PR DESCRIPTION
All other SP7 platforms configured the static I3C addresses for SBRMI and SBTSI I3C devices. Without this, P1 SBRMI and SBTSI will fail to bind the driver.
```
 i3c_device_match_id: manuf 0x0, part 0x0, inst 0x0, ext_info 0x118
sbtsi_i3c 4-118: SBTSI: PID: 118
sbtsi_i3c 4-118: register sbtsi-9 device
APML: Registered SBTSI device at address 0x9
...
 i3c_device_match_id: manuf 0x0, part 0x100, inst 0x0, ext_info 0x118
sbtsi_i3c 5-1000118: SBTSI: PID: 1000118
sysfs: cannot create duplicate filename '/class/misc/sbtsi-9'
CPU: 2 PID: 30983 Comm: s0-state-mgr Tainted: G           O       6.6.92-dirty-9baaae4348bb-g9baaae4348bb #1
Hardware name: AMD Ghana PRB (DT)
Call trace:
 dump_backtrace+0xa0/0x11c
 show_stack+0x18/0x24
 dump_stack_lvl+0x48/0x60
 dump_stack+0x18/0x24
 sysfs_warn_dup+0x64/0x80
 sysfs_do_create_link_sd+0xf0/0xf8
 sysfs_create_link+0x20/0x40
 device_add+0x2fc/0x7ec
 device_create_groups_vargs+0xe0/0x134
 device_create_with_groups+0x58/0x84
 misc_register+0xd8/0x188
 create_misc_tsi_device+0x78/0xac
 sbtsi_i3c_probe+0x140/0x214
 i3c_device_probe+0x18/0x24
 really_probe+0x160/0x3d8
 __driver_probe_device+0x88/0x170
 device_driver_attach+0x48/0xac
 bind_store+0x7c/0xd0
 drv_attr_store+0x24/0x38
 sysfs_kf_write+0x44/0x54
 kernfs_fop_write_iter+0x134/0x1e0
 vfs_write+0x190/0x314
 ksys_write+0x70/0x108
 __arm64_sys_write+0x1c/0x28
 invoke_syscall.constprop.0+0x5c/0x100
 do_el0_svc+0xa8/0xc8
 el0_svc+0x40/0x128
 el0t_64_sync_handler+0x120/0x12c
 el0t_64_sync+0x190/0x194
sbtsi_i3c: probe of 5-1000118 failed with error -17
```

Statically set the I3C addresses for SBRMI/SBTSI for Ghana as well.

Tested:
Driver binding for Ghana now succeeds for P1 SBRMI and SBTSI.