### PR TITLE
usb:gadget:hid: allow dynamic interval config

### DIFF
--- a/drivers/usb/gadget/function/f_hid.c
+++ b/drivers/usb/gadget/function/f_hid.c
@@ -49,6 +49,8 @@ struct f_hidg {
 	unsigned short			report_desc_length;
 	char				*report_desc;
 	unsigned short			report_length;
+	unsigned char			interval;
+	bool				interval_user_set;
 	/*
 	 * use_out_ep - if true, the OUT Endpoint (interrupt out method)
 	 *              will be used to receive reports from the host
@@ -967,6 +969,20 @@ static int hidg_bind(struct usb_configuration *c, struct usb_function *f)
 	hidg_hs_out_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
 	hidg_fs_out_ep_desc.wMaxPacketSize = cpu_to_le16(hidg->report_length);
 	/*
+	 * Override the endpoint polling interval when the user configured one
+	 * via configfs ("interval"). When unset, keep the descriptor defaults.
+	 * A larger interval reduces host interrupt-endpoint polling, which
+	 * lets the PCIe/xHCI path idle (improves host DF C-state residency).
+	 */
+	if (hidg->interval_user_set) {
+		hidg_ss_in_ep_desc.bInterval = hidg->interval;
+		hidg_hs_in_ep_desc.bInterval = hidg->interval;
+		hidg_fs_in_ep_desc.bInterval = hidg->interval;
+		hidg_ss_out_ep_desc.bInterval = hidg->interval;
+		hidg_hs_out_ep_desc.bInterval = hidg->interval;
+		hidg_fs_out_ep_desc.bInterval = hidg->interval;
+	}
+	/*
 	 * We can use hidg_desc struct here but we should not relay
 	 * that its content won't change after returning from this function.
 	 */
@@ -1104,6 +1120,46 @@ F_HID_OPT(protocol, 8, 255);
 F_HID_OPT(no_out_endpoint, 8, 1);
 F_HID_OPT(report_length, 16, 65535);
 
+static ssize_t f_hid_opts_interval_show(struct config_item *item, char *page)
+{
+	struct f_hid_opts *opts = to_f_hid_opts(item);
+	int result;
+
+	mutex_lock(&opts->lock);
+	result = sprintf(page, "%d\n", opts->interval);
+	mutex_unlock(&opts->lock);
+
+	return result;
+}
+
+static ssize_t f_hid_opts_interval_store(struct config_item *item,
+					 const char *page, size_t len)
+{
+	struct f_hid_opts *opts = to_f_hid_opts(item);
+	int ret;
+	u8 num;
+
+	mutex_lock(&opts->lock);
+	if (opts->refcnt) {
+		ret = -EBUSY;
+		goto end;
+	}
+
+	ret = kstrtou8(page, 0, &num);
+	if (ret)
+		goto end;
+
+	opts->interval = num;
+	opts->interval_user_set = true;
+	ret = len;
+
+end:
+	mutex_unlock(&opts->lock);
+	return ret;
+}
+
+CONFIGFS_ATTR(f_hid_opts_, interval);
+
 static ssize_t f_hid_opts_report_desc_show(struct config_item *item, char *page)
 {
 	struct f_hid_opts *opts = to_f_hid_opts(item);
@@ -1163,6 +1219,7 @@ static struct configfs_attribute *hid_attrs[] = {
 	&f_hid_opts_attr_protocol,
 	&f_hid_opts_attr_no_out_endpoint,
 	&f_hid_opts_attr_report_length,
+	&f_hid_opts_attr_interval,
 	&f_hid_opts_attr_report_desc,
 	&f_hid_opts_attr_dev,
 	NULL,
@@ -1211,6 +1268,10 @@ static struct usb_function_instance *hidg_alloc_inst(void)
 	mutex_init(&opts->lock);
 	opts->func_inst.free_func_inst = hidg_free_inst;
 	ret = &opts->func_inst;
+
+	/* Default matches the legacy hard-coded HS/SS bInterval (4). */
+	opts->interval = 4;
+	opts->interval_user_set = false;
 
 	mutex_lock(&hidg_ida_lock);
 
@@ -1287,6 +1348,8 @@ static struct usb_function *hidg_alloc(struct usb_function_instance *fi)
 	hidg->bInterfaceProtocol = opts->protocol;
 	hidg->report_length = opts->report_length;
 	hidg->report_desc_length = opts->report_desc_length;
+	hidg->interval = opts->interval;
+	hidg->interval_user_set = opts->interval_user_set;
 	if (opts->report_desc) {
 		hidg->report_desc = kmemdup(opts->report_desc,
 					    opts->report_desc_length,

--- a/drivers/usb/gadget/function/u_hid.h
+++ b/drivers/usb/gadget/function/u_hid.h
@@ -25,6 +25,8 @@ struct f_hid_opts {
 	unsigned short			report_desc_length;
 	unsigned char			*report_desc;
 	bool				report_desc_alloc;
+	unsigned char			interval;
+	bool				interval_user_set;
 
 	/*
 	 * Protect the data form concurrent access by read/write


### PR DESCRIPTION
Backport of upstream commit ea34925f5b2e. The HID gadget interrupt endpoint bInterval was hard-coded (HS/SS=4 -> 1ms poll), forcing the host xHCI to poll the (always-connected, non-suspendable) iKVM stub keyboard ~1000x/sec over PCIe. That constant traffic prevents the host AMD Data Fabric from reaching deep C-states, capping idle DFCS residency at ~65%.

Add an "interval" configfs attribute so create_usbhid.sh can raise the stub keyboard's poll interval (e.g. 16 -> ~4s at HS), drastically cutting BMC->host PCIe wakeups while keeping the anti-suspend stub (preserving the Windows KVM idle fix). Default behavior is unchanged when "interval" is not written.

Upstream-Status: Inappropriate