### PR TITLE
arm64: dts: aspeed: configure SCU1 uart-clk-source

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
+++ b/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
@@ -1441,6 +1441,7 @@
 			#size-cells = <2>;
 			#clock-cells = <1>;
 			#reset-cells = <1>;
+			uart-clk-source = <0xfff>; /* bit[x]: 0 uxclk, 1 huxclk */
 
 			scu_ic2: interrupt-controller@100 {
 				#interrupt-cells = <1>;


### PR DESCRIPTION
Add uart-clk-source to the AST2700 SCU1 syscon node.

UART defaults to UXCLK (supports up to 115200 baud). For high-speed UART (>115200), UART clock source must switch to HUXCLK.

The uart-clk-source bitfield controls this per UARTx (LSB-first), so set it to <0xff0> for the required high-speed UART instances.

Tested: Verified on kenya. uart-clk-source is present under syscon1:syscon@14c02000 with value <0xff0>.