### PR TITLE
drivers:net:mctp: set the target as bridge always

### DIFF
--- a/drivers/net/mctp/mctp-pcie.c
+++ b/drivers/net/mctp/mctp-pcie.c
@@ -118,8 +118,8 @@ static int mctp_netdev_header_create(struct sk_buff *skb, struct net_device *dev
 	hdr->code = 0x7F;
 
 	/*
-	 * set the target as Bridge bdf 0/0/0.
-	 * Bridge can route the MCTP requests based on the MCTP EID mapping
+	 * Set the target to MPIO Virtual Bridge with fixed BDF 0/0/0.
+	 * Bridge can route MCTP requests based on MCTP EID mapping.
 	 */
 	memset(hdr->target, 0, sizeof(hdr->target));
 

--- a/drivers/net/mctp/mctp-pcie.c
+++ b/drivers/net/mctp/mctp-pcie.c
@@ -116,7 +116,13 @@ static int mctp_netdev_header_create(struct sk_buff *skb, struct net_device *dev
 	memcpy(&hdr->requester, saddr, 2);
 	hdr->tag = ((4 - ((len - 4) % 4)) & 0x3) << 4;
 	hdr->code = 0x7F;
-	memcpy(&hdr->target, daddr, 2);
+
+	/*
+	 * set the target as Bridge bdf 0/0/0.
+	 * Bridge can route the MCTP requests based on the MCTP EID mapping
+	 */
+	memset(hdr->target, 0, sizeof(hdr->target));
+
 	hdr->vendor[0] = 0x1A;
 	hdr->vendor[1] = 0xB4;
 	mhdr->ver = 0x01;


### PR DESCRIPTION
Send all the MCTP requests to the PCIe bridge address with 0/0/0 as bdf. Current implementation of the driver does not support segment number as part of the address. If the PCIe devices are configured in multiple segments, MCTP messages addressed to the device b/d/f are not routed correctly. If the MCTP messages are routed to the bridge, bridge can forward the request based on its MCTP EID and b/d/f mapping.

tested: verified on Congo