### PR TITLE
drivers:i3c:mipi: drop spurious IBI entries for addr 0x00

### DIFF
--- a/drivers/i3c/master/mipi-i3c-hci/dma.c
+++ b/drivers/i3c/master/mipi-i3c-hci/dma.c
@@ -741,16 +741,25 @@ static void hci_dma_process_ibi(struct i3c_hci *hci, struct hci_rh_data *rh)
 	deq_ptr %= rh->ibi_status_entries;
 	if (!hci->master.target) {
 		if (ibi_status_error) {
-			dev_err(&hci->master.dev, "IBI error from %#x\n",
+			dev_err_ratelimited(&hci->master.dev, "IBI error from %#x\n",
 				ibi_addr);
 			goto done;
 		}
+		/*
+		 * 0x00 is a reserved I3C address and can never be an assigned
+		 * dynamic address, so a status entry decoding to addr 0 is a
+		 * spurious/empty descriptor, not a real IBI/HJ/CR. Drop it
+		 * before classificatio so it cannot be misread as a CR (or
+		 * fall through to the "unknown device" path).
+		 */
+		if (ibi_addr == 0)
+			goto done;
 		if (IBI_TYPE_HJ(ibi_addr, ibi_rnw)) {
 			queue_work(hci->master.wq, &hci->hj_work);
 			goto done;
 		} else if (IBI_TYPE_CR(ibi_addr, ibi_rnw)) {
-			dev_info(&hci->master.dev,
-				 "get control role requeset from %02x\n",
+			dev_info_ratelimited(&hci->master.dev,
+				 "get control role requeset from %#x\n",
 				 ibi_addr);
 			goto done;
 		}
@@ -758,7 +767,7 @@ static void hci_dma_process_ibi(struct i3c_hci *hci, struct hci_rh_data *rh)
 		/* determine who this is for */
 		dev = i3c_hci_addr_to_dev(hci, ibi_addr);
 		if (!dev) {
-			dev_err(&hci->master.dev,
+			dev_err_ratelimited(&hci->master.dev,
 				"IBI for unknown device %#x\n", ibi_addr);
 			goto done;
 		}
@@ -766,7 +775,7 @@ static void hci_dma_process_ibi(struct i3c_hci *hci, struct hci_rh_data *rh)
 		dev_data = i3c_dev_get_master_data(dev);
 		dev_ibi = dev_data->ibi_data;
 		if (ibi_size > dev_ibi->max_len) {
-			dev_err(&hci->master.dev,
+			dev_err_ratelimited(&hci->master.dev,
 				"IBI payload too big (%d > %d)\n", ibi_size,
 				dev_ibi->max_len);
 			goto done;
@@ -784,7 +793,7 @@ static void hci_dma_process_ibi(struct i3c_hci *hci, struct hci_rh_data *rh)
 		 */
 		slot = i3c_generic_ibi_get_free_slot(dev_ibi->pool);
 		if (!slot) {
-			dev_err(&hci->master.dev, "no free slot for IBI\n");
+			dev_err_ratelimited(&hci->master.dev, "no free slot for IBI\n");
 			goto done;
 		}
 	}

--- a/drivers/i3c/master/mipi-i3c-hci/pio.c
+++ b/drivers/i3c/master/mipi-i3c-hci/pio.c
@@ -1023,18 +1023,25 @@ static bool hci_pio_prep_new_ibi(struct i3c_hci *hci, struct hci_pio_data *pio)
 	DBG("status = %#x", ibi_status);
 	ibi_addr = FIELD_GET(IBI_TARGET_ADDR, ibi_status);
 	ibi_rnw = FIELD_GET(IBI_TARGET_RNW, ibi_status);
+	/*
+	 * 0x00 is a reserved I3C address and can never be an assigned
+	 * dynamic address; a status entry decoding to addr 0 is a spurious
+	 * descriptor, not a real IBI/HJ/CR. Drop it before classification.
+	 */
+	if (ibi_addr == 0)
+		return false;
 	if (IBI_TYPE_HJ(ibi_addr, ibi_rnw)) {
 		queue_work(hci->master.wq, &hci->hj_work);
 		return false;
 	} else if (IBI_TYPE_CR(ibi_addr, ibi_rnw)) {
-		dev_info(&hci->master.dev,
-			 "get control role requeset from %02lx\n",
+		dev_info_ratelimited(&hci->master.dev,
+			 "get control role requeset from %#lx\n",
 			 FIELD_GET(IBI_TARGET_ADDR, ibi_status));
 		return false;
 	} else {
 		ibi->addr = FIELD_GET(IBI_TARGET_ADDR, ibi_status);
 		if (ibi_status & IBI_ERROR) {
-			dev_err(&hci->master.dev, "IBI error from %#x\n", ibi->addr);
+			dev_err_ratelimited(&hci->master.dev, "IBI error from %#x\n", ibi->addr);
 			return false;
 		}
 	}
@@ -1045,7 +1052,7 @@ static bool hci_pio_prep_new_ibi(struct i3c_hci *hci, struct hci_pio_data *pio)
 
 	dev = i3c_hci_addr_to_dev(hci, ibi->addr);
 	if (!dev) {
-		dev_err(&hci->master.dev,
+		dev_err_ratelimited(&hci->master.dev,
 			"IBI for unknown device %#x\n", ibi->addr);
 		return true;
 	}
@@ -1055,14 +1062,14 @@ static bool hci_pio_prep_new_ibi(struct i3c_hci *hci, struct hci_pio_data *pio)
 	ibi->max_len = dev_ibi->max_len;
 
 	if (ibi->seg_len > ibi->max_len) {
-		dev_err(&hci->master.dev, "IBI payload too big (%d > %d)\n",
+		dev_err_ratelimited(&hci->master.dev, "IBI payload too big (%d > %d)\n",
 			ibi->seg_len, ibi->max_len);
 		return true;
 	}
 
 	ibi->slot = i3c_generic_ibi_get_free_slot(dev_ibi->pool);
 	if (!ibi->slot) {
-		dev_err(&hci->master.dev, "no free slot for IBI\n");
+		dev_err_ratelimited(&hci->master.dev, "no free slot for IBI\n");
 	} else {
 		ibi->slot->len = 0;
 		ibi->data_ptr = ibi->slot->data;


### PR DESCRIPTION
- the SP8 controller posts IBI status descriptors whose target-address field decodes to 0x00 (reserved dynamic address)
- Drop these entries early, before HJ/CR classification.
- convertbthe remaining IBI-path dev-err() calls in this handler to dev_err_ratelimited(), so a garbage descriptor decoding to any other unexpected address cannot livelock the CPU either.

tested:
- verified in Nigeria