### PR TITLE
arm64: dts: aspeed: Correct gpio nodes

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
@@ -596,7 +596,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 };
 #endif
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	p0_sec_i2c {
@@ -606,10 +606,6 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 		line-name = "SEL_P0_SEC_I2C_ROT_BMC";
 	};
 
-};
-
-&gpio1 {
-	status = "okay";
 	/* Rev-B HPM EN line on gpiochip1 C7 */
 	hpm_en_rev_b_default {
 		gpio-hog;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -927,7 +927,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
@@ -910,7 +910,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
@@ -469,7 +469,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -692,7 +692,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 	espi_default {
 		gpio-hog;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
@@ -988,7 +988,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -953,7 +953,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -570,7 +570,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(0, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1120,7 +1120,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -886,7 +886,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 	espi_default {
 		gpio-hog;

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigerias3.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigerias3.dts
@@ -321,7 +321,7 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 };
 #endif
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -678,7 +678,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	JESD300_PMIC_I2C_MODE(1, 7, 4f);
 };
 
-&gpio0 {
+&gpio1 {
 	status = "okay";
 
 	/*


### PR DESCRIPTION
Aspeed swapped gpio0 and gpio1 labels during the migration to 6.18.
https://github.com/AspeedTech-BMC/linux/commit/e7e13542bdb386b9b2fce92f53d51e1fe16e0576

Adjust for this change in AMD platforms.

Tested:
Verified in SP7/SP8 build.