### PR TITLE
arm64: dts: disable unused AST USB3 AHP controller

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
@@ -1167,8 +1167,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 };
 
 &usb3ahp {
-	status = "okay";
-	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+	status = "disabled";
 };
 
 &usb3bhp {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -1191,8 +1191,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 };
 
 &usb3ahp {
-	status = "okay";
-	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+	status = "disabled";
 };
 
 &usb3bhp {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1351,8 +1351,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 };
 
 &usb3ahp {
-	status = "okay";
-	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+	status = "disabled"
 };
 
 &usb3bhp {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1128,8 +1128,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 };
 
 &usb3ahp {
-	status = "okay";
-	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+	status = "disabled";
 };
 
 &usb3bhp {

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -917,8 +917,7 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 };
 
 &usb3ahp {
-	status = "okay";
-	pinctrl-0 = <&pinctrl_usb3axhp_default &pinctrl_usb2axhp_default>;
+	status = "disabled";
 };
 
 &usb3bhp {


### PR DESCRIPTION
the secondary ASPEED USB3 AHP/vHUB path is not used but remains enabled in the device tree. This results in an extra ASPEED USB controller being enumerated by the OS and causes the Windows Server HLK USB Exposed Port Test to fail.

Tested: Tested on SP7 2P system.
- It successfully disables Port A’s PCIe-XHCI-PHY and does not expose it to Windows.