### PR TITLE
eMMC and UART clock changes on AMD platforms

### DIFF
--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-arthur.dts
@@ -746,6 +746,14 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -753,8 +761,9 @@ spd_ ## bus ## _ ## index: spd@addr,4cc5118 ## index ## 000 { \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-congo.dts
@@ -1092,6 +1092,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -1099,8 +1107,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-eagle.dts
@@ -1054,6 +1054,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -1061,8 +1069,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-falcon.dts
@@ -617,6 +617,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -624,8 +632,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-ghana.dts
@@ -921,6 +921,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -928,8 +936,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill-mps.dts
@@ -1226,6 +1226,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -1233,8 +1241,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-hornbill.dts
@@ -1176,6 +1176,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -1183,8 +1191,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-kenya.dts
@@ -740,6 +740,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -747,8 +755,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-morocco.dts
@@ -1364,6 +1364,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -1371,8 +1379,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-nigeria.dts
@@ -1115,6 +1115,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -1122,8 +1130,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
+++ b/arch/arm64/boot/dts/aspeed/aspeed-bmc-amd-seagull.dts
@@ -901,6 +901,14 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 	memory-region = <&bmc_dev0_memory>;
 };
 
+&pinctrl0 {
+	pinctrl_emmc_8ma: emmc_8ma {
+		pins = "AC14", "AE15", "AD14", "AE14", "AF14",
+		       "AB13", "AF13", "AC13", "AD13", "AE13";
+		drive-strength = <2>;
+	};
+};
+
 &emmc_controller {
 	status = "okay";
 	mmc-hs200-1_8v;
@@ -908,8 +916,9 @@ pmic_ ## bus ## _ ## index: pmic@addr{ \
 
 &emmc {
 	status = "okay";
-	bus-width = <4>;
-	pinctrl-0 = <&pinctrl_emmc_default>;
+	bus-width = <8>;
+	pinctrl-0 = <&pinctrl_emmc_default &pinctrl_emmcg8_default
+		     &pinctrl_emmc_8ma>;
 	non-removable;
 	max-frequency = <200000000>;
 };

--- a/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
+++ b/arch/arm64/boot/dts/aspeed/aspeed-g7.dtsi
@@ -1518,6 +1518,7 @@
 			#size-cells = <1>;
 			#clock-cells = <1>;
 			#reset-cells = <1>;
+			uart-clk-source = <0xfff>; /* bit[x]: 0 uxclk, 1 huxclk */
 
 			assigned-clocks = <&syscon1 SCU1_CLK_MACHCLK>,
 					  <&syscon1 SCU1_CLK_RGMII>,


### PR DESCRIPTION
- cherrypicked high speed UART clock speed from integ_sp8 to dev-6.18
- enable 8-bit width for eMMC and increase drive strength to 8mA